### PR TITLE
Mock npm adduser server response, fixing #5

### DIFF
--- a/controllers/registry/module.js
+++ b/controllers/registry/module.js
@@ -29,7 +29,7 @@ exports.show = function (req, res) {
   res.json(MOCK_MODULE_DATA);
 };
 
-exports.update = function (req, res) {
+exports.add = function (req, res) {
   var params = req.params;
   if (params.module === 'exist') {
     res.statusCode = 409;

--- a/controllers/registry/session.js
+++ b/controllers/registry/session.js
@@ -1,0 +1,26 @@
+/*!
+ * cnpmjs.org - controllers/registry/session.js
+ *
+ * Copyright(c) cnpmjs.org and other contributors.
+ * MIT Licensed
+ *
+ * Authors:
+ *  dead_horse <dead_horse@qq.com>
+ */
+
+'use strict';
+
+/**
+ * Module dependencies.
+ */
+
+var MOCK_SESSION = 'ZGVhZF9ob3JzZTo1MjlFRkEwQzr9pL4PaOaFsKPycBcfGZFGBL5T7g';
+
+exports.add = function (req, res) {
+  res.cookie('AuthSession', MOCK_SESSION);
+  res.json({
+    ok: true,
+    name: req.body.name,
+    roles: []
+  });
+};

--- a/controllers/registry/user.js
+++ b/controllers/registry/user.js
@@ -1,0 +1,63 @@
+/*!
+ * cnpmjs.org - controllers/registry/user.js
+ *
+ * Copyright(c) cnpmjs.org and other contributors.
+ * MIT Licensed
+ *
+ * Authors:
+ *  dead_horse <dead_horse@qq.com>
+ */
+
+'use strict';
+
+/**
+ * Module dependencies.
+ */
+
+var MOCK_USER_DATA = {
+  _id: 'org.couchdb.user:exist',
+  _rev: '24-29a410ffe8c2250d3ca1a856d8f913ad',
+  name: 'exist',
+  email: 'exist@gmail.com',
+  type: 'user',
+  roles: [],
+  date: '2013-12-04T02:03:08.540Z',
+  mustChangePass: false,
+  _etag: '"24-29a410ffe8c2250d3ca1a856d8f913ad"' 
+};
+
+exports.show = function (req, res) {
+  var name = req.params.name;
+   //auth token in header: authorization: 'Basic ZXhpc3EWdf=='
+  var auth = (req.headers.authorization || '').split(' ')[1];
+
+  //mock, only exist with passworld 123 can pass this
+  if (auth !== 'ZXhpc3Q6MTIz') {
+    res.statusCode = 401;
+    return res.json({
+      error: 'unauthorized', 
+      reason: 'Name or password is incorrect.'
+    });
+  }
+  res.statusCode = 200;
+  res.json(MOCK_USER_DATA);
+};
+
+exports.add = function (req, res) {
+  var name = req.params.name;
+  //mock only username === exist return 409
+  if (name === 'org.couchdb.user:exist') {
+    res.statusCode = 409;
+    return res.json({
+      error: 'conflict', 
+      reason: 'Document update conflict.' 
+    });
+  }
+  res.statusCode = 201;
+  res.end();
+};
+
+exports.upload = function (req, res) {
+  res.statusCode = 201;
+  res.end();
+};

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "ms": "~0.6.1",
     "mkdirp": "~0.3.5",
     "mysql": "2.0.0-rc1",
-    "response-patch": "~0.1.1"
+    "response-patch": "~0.1.1",
+    "response-cookie": "~0.0.2"
   },
   "devDependencies": {
     "should": "*",

--- a/routes/registry.js
+++ b/routes/registry.js
@@ -18,16 +18,25 @@
 var mod = require('../controllers/registry/module');
 var pkg = require('../controllers/registry/package');
 var tag = require('../controllers/registry/tag');
+var user = require('../controllers/registry/user');
+var session = require('../controllers/registry/session');
 
 function routes(app) {
   app.get('/:name', mod.show);
-  app.put('/:name', mod.update);
+  app.put('/:name', mod.add);
 
   // put tarball
   // https://registry.npmjs.org/cnpmjs.org/-/cnpmjs.org-0.0.0.tgz/-rev/1-c85bc65e8d2470cc4d82b8f40da65b8e
   app.put('/:name/-/:filename/-rev/:rev', pkg.upload);
   // tag
   app.put('/:name/:version/-tag/latest', tag.updateLatest);
+
+  //try to create a new user
+  app.put('/-/user/:name', user.add);
+  app.get('/-/user/:name', user.show);
+  app.put('/-/user/:name/-rev/:rev', user.upload);
+
+  app.post('/_session', session.add);
 }
 
 module.exports = routes;

--- a/servers/registry.js
+++ b/servers/registry.js
@@ -19,6 +19,7 @@ require('response-patch');
 var http = require('http');
 var connect = require('connect');
 var rt = require('connect-rt');
+var responseCookie = require('response-cookie');
 var urlrouter = require('urlrouter');
 var routes = require('../routes/registry');
 var logger = require('../common/logger');
@@ -31,6 +32,7 @@ app.use(function (req, res, next) {
   res.req = req;
   next();
 });
+app.use(responseCookie());
 app.use(connect.query());
 app.use(connect.bodyParser());
 


### PR DESCRIPTION
put /-/user/:name first
if return 201 adduser ok,
else if return 409, means user exist

then get /-/user/:name with header authorization: 'Basic adasdadasdad=='
if check ok, return 200 and account info. then put/-/user/:name/-rev/:rev
if check not ok, return 401, adduser error.

adduser the same account:
It will post /_session to get authSession.
