### PR TITLE
fix signed cookie not work on npm@1.3.25; node --harmony-generators

### DIFF
--- a/bin/nodejsctl
+++ b/bin/nodejsctl
@@ -7,7 +7,7 @@ export NODE_ENV='production'
 ulimit -c unlimited
 
 cd `dirname $0`/..
-NODEJS=node
+NODEJS='node --harmony-generators'
 BASE_HOME=`pwd`
 PROJECT_NAME=`basename ${BASE_HOME}`
 STDOUT_LOG=`$NODEJS -e "console.log(require('path').join(require('$BASE_HOME/config').logdir, 'nodejs_stdout.log'));\

--- a/common/session.js
+++ b/common/session.js
@@ -20,7 +20,7 @@ var redisStore = require('koa-redis');
 var config = require('../config');
 
 var key = 'AuthSession';
-var cookie = { path: '/', httpOnly: true, maxAge: 3600000 * 24 * 30 };
+var cookie = { path: '/', httpOnly: true, maxAge: 3600000 * 24 * 365, signed: false };
 var options = {
   key: key,
   cookie: cookie,

--- a/middleware/auth.js
+++ b/middleware/auth.js
@@ -21,6 +21,7 @@ var common = require('../lib/common');
 
 module.exports = function (options) {
   return function *auth(next) {
+    debug('%s, %s, %j', this.url, this.sessionId, this.session);
     if (!this.session) {
       // redis crash
       this.session = {};


### PR DESCRIPTION
```
nvm use 0.11
tcnpm publish // will break 401 when cookie.signed = true
```
