### PR TITLE
sync work sync one done must wait for a defer.setImmediate. fix #328

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "co": "3.0.5",
+    "co-defer": "0.1.0",
     "co-gather": "0.0.1",
     "co-read": "0.0.2",
     "co-redis": "1.1.0",
@@ -36,7 +37,7 @@
     "ms": "0.6.2",
     "multiline": "0.3.2",
     "mysql": "2.1.1",
-    "nodemailer": "0.6.2",
+    "nodemailer": "0.6.3",
     "qn": "0.2.1",
     "ready": "0.1.1",
     "redis": "0.10.1",
@@ -55,7 +56,7 @@
     "mm": "0.2.1",
     "mocha": "*",
     "pedding": "0.0.3",
-    "should": "3.3.0",
+    "should": "3.3.1",
     "supertest": "0.11.0"
   },
   "homepage": "https://github.com/cnpm/cnpmjs.org",

--- a/test/sync/sync_all.test.js
+++ b/test/sync/sync_all.test.js
@@ -25,13 +25,14 @@ describe('sync/sync_all.test.js', function () {
     afterEach(mm.restore);
 
     it('should sync first time ok', function *() {
-      mm.data(Npm, 'getShort', ['mk2testmodule']);
+      mm.data(Npm, 'getShort', ['mk2testmodule', 'mk2testmodule-not-exists']);
       mm.data(Total, 'getTotalInfo', {last_sync_time: 0});
       var data = yield sync;
-      data.successes.should.eql(['mk2testmodule']);
+      data.successes.should.eql(['mk2testmodule', 'mk2testmodule-not-exists']);
       mm.restore();
       var result = yield Total.getTotalInfo();
-      result.last_sync_module.should.equal('mk2testmodule');
+      should.exist(result);
+      result.last_sync_module.should.equal('mk2testmodule-not-exists');
     });
 
     it('should sync common ok', function *() {


### PR DESCRIPTION
总算找到 sync worker 的内存问题所在了.

我们换成 co 之后, 堆栈一直保存着, 导致无法释放内存.

必须在 一个 next() 完整之后, 先 setImmediate 释放掉堆栈信息后, 再重新执行.
