### PR TITLE
feat(sync): add min sync interval time detect

### DIFF
--- a/sync/index.js
+++ b/sync/index.js
@@ -58,7 +58,7 @@ var handleSync = co(function *() {
     var data;
     var error;
     try {
-      data = yield *sync();
+      data = yield* sync();
     } catch (err) {
       error = err;
       error.message += ' (sync package error)';
@@ -74,7 +74,12 @@ var handleSync = co(function *() {
 
 if (sync) {
   handleSync();
-  setInterval(handleSync, ms(config.syncInterval));
+  var syncInterval = ms(config.syncInterval);
+  var minSyncInterval = ms('5m');
+  if (!syncInterval || syncInterval < minSyncInterval) {
+    syncInterval = minSyncInterval;
+  }
+  setInterval(handleSync, syncInterval);
 }
 
 /**


### PR DESCRIPTION
Forbidden some guy write `config.syncInterval = 1` to let sync too fast.

Closes #486

This is cherry-pick 9ce8482a13d790aece8880a841a8ed26752e8277 into 1.x 
