### PR TITLE
feat: support always-auth

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -213,6 +213,10 @@ var config = {
 
   // custom user service, @see https://github.com/cnpm/cnpmjs.org/wiki/Use-Your-Own-User-Authorization
   userService: null,
+
+  // always-auth https://docs.npmjs.com/misc/config#always-auth
+  // Force npm to always require authentication when accessing the registry, even for GET requests.
+  alwaysAuth: false,
 };
 
 if (process.env.NODE_ENV !== 'test') {

--- a/servers/registry.js
+++ b/servers/registry.js
@@ -38,12 +38,12 @@ app.use(staticCache);
 
 app.keys = ['todokey', config.sessionSecret];
 app.proxy = true;
-app.use(proxyToNpm());
 app.use(middlewares.bodyParser({jsonLimit: config.jsonLimit}));
 app.use(cors({
   allowMethods: 'GET,HEAD'
 }));
 app.use(auth());
+app.use(proxyToNpm());
 app.use(notFound);
 
 if (config.enableCompress) {

--- a/test/middleware/auth.test.js
+++ b/test/middleware/auth.test.js
@@ -6,7 +6,7 @@
  *
  * Authors:
  *  dead_horse <dead_horse@qq.com> (http://deadhorse.me)
- *  fengmk2 <fengmk2@gmail.com> (http://fengmk2.github.com)
+ *  fengmk2 <fengmk2@gmail.com> (http://fengmk2.com)
  */
 
 'use strict';
@@ -75,6 +75,31 @@ describe('middleware/auth.test.js', function () {
         })
         .expect(401, done);
       });
+    });
+  });
+
+  describe('config.alwaysAuth = true', function () {
+    beforeEach(function () {
+      mm(config, 'alwaysAuth', true);
+    });
+
+    it('should required auth for GET registry request', function (done) {
+      request(app)
+      .get('/')
+      .set('Accept', 'application/json')
+      .expect({
+        error: 'unauthorized',
+        reason: 'login first'
+      })
+      .expect(401, done);
+    });
+
+    it('should required auth for GET web request', function (done) {
+      request(app)
+      .get('/')
+      .set('Accept', 'text/html')
+      .expect('login first')
+      .expect(401, done);
     });
   });
 });


### PR DESCRIPTION
Add `alwaysAuth: true` to config and set npm cli config.

Use 'http://registry.sample.com' for example, set npm config below:

    $ npm config set '//registry.sample.com/:always-auth=true'
    $ npm login --registry=http://registry.sample.com
    $ npm install mocha --registry=http://registry.sample.com

Fixes #600