### PR TITLE
fix(list): let koa-etag to caculate the etag

### DIFF
--- a/controllers/registry/package/list.js
+++ b/controllers/registry/package/list.js
@@ -45,9 +45,6 @@ module.exports = function* list() {
       }
     }
 
-    // use modifiedTime as etag
-    this.set('ETag', '"' + modifiedTime.getTime() + '"');
-
     // must set status first
     this.status = 200;
     if (this.fresh) {


### PR DESCRIPTION
只用这个表的 modifiedTime 做 etag 不对，在 unpublish 的时候会先修改这张表的数据，然后调用一次 list，再删除 tag 和文件，导致缓存了一个 etag 和最终的 etag 一致，但是内容不一致