### PR TITLE
fix: http://cnpmjs.org/package/fms pre style

### DIFF
--- a/public/css/github-markdown.css
+++ b/public/css/github-markdown.css
@@ -453,6 +453,7 @@
   font-size: 85%;
   line-height: 1.45;
   background-color: #f7f7f7;
+  color:#333;
   border-radius: 3px;
 }
 


### PR DESCRIPTION
http://cnpmjs.org/package/fms 
自动生成数据文档章节的 pre 标签 color 值使用了 main.css 的 `color: #fff;`