### PR TITLE
fix: 启动 cli , config.json 无效

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -78,6 +78,7 @@ function start(options) {
   }
 
   var configJSON = JSON.stringify(config, null, 2);
+  configfile = path.join(options.dataDir || process.env.HOME, '.cnpmjs.org', 'config.json');
   fs.writeFileSync(configfile, configJSON);
 
   debug('save config %s to %s', configJSON, configfile);


### PR DESCRIPTION
 原 cli 里 config.json 只是复写自己，没有写到 .npmjs.org 目录下，导致 config 没有读取到 config.json。

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cnpm/cnpmjs.org/851)

<!-- Reviewable:end -->
