### PR TITLE
A workaround for bug npm/npm#9616. And the reason was listed in issue…

### DIFF
--- a/controllers/registry/package/list.js
+++ b/controllers/registry/package/list.js
@@ -15,6 +15,10 @@ var config = require('../../../config');
  * GET /:name
  */
 module.exports = function* list() {
+  // Notice, this is a workaround because of NPM bug npm/npm#9616.
+  // After npm fixed this bug, you shall delete this line.
+  common.decodeScopedPackageName(this.params);
+
   var orginalName = this.params.name || this.params[0];
   var name = orginalName;
   var rs = yield [

--- a/lib/common.js
+++ b/lib/common.js
@@ -78,3 +78,15 @@ exports.isPrivateScopedPackage = function (name) {
   }
   return config.scopes.indexOf(name.split('/')[0]) >= 0;
 };
+
+// This function ONLY used as a workaround to fix npm/npm#9616 bug.
+// The reason was listed in issue cnpm/cnpmjs.org#1024.
+exports.decodeScopedPackageName = function (params) {
+  if (params.name) {
+    params.name = decodeURIComponent(params.name);
+  }
+
+  if (params[0]) {
+    params[0] = decodeURIComponent(params[0]);
+  }
+};

--- a/middleware/publishable.js
+++ b/middleware/publishable.js
@@ -17,6 +17,7 @@
 var util = require('util');
 var config = require('../config');
 var debug = require('debug')('cnpmjs.org:middlewares/publishable');
+var common = require('../lib/common');
 
 module.exports = function *publishable(next) {
   // admins always can publish and unpublish
@@ -33,6 +34,9 @@ module.exports = function *publishable(next) {
     };
     return;
   }
+
+  // See more at npm/npm#9616 and cnpmjs/cnpmjs.org#1024
+  common.decodeScopedPackageName(this.params);
 
   // public mode, normal user have permission to publish `scoped package`
   // and only can publish with scopes in `ctx.user.scopes`, default is `config.scopes`


### PR DESCRIPTION
… cnpmjs/cnpmjs.org#1024.

For now, this workaround just takes care of `npm install` and `npm publish`.