### PR TITLE
fix: ignore long package name on unpublished sync

### DIFF
--- a/controllers/sync_module_worker.js
+++ b/controllers/sync_module_worker.js
@@ -324,7 +324,8 @@ SyncModuleWorker.prototype.next = function* (concurrencyId) {
   var unpublishedInfo = null;
   if (status === 404) {
     // check if it's unpublished
-    if (pkg && pkg.time && pkg.time.unpublished && pkg.time.unpublished.time) {
+    // ignore too long package name, see https://github.com/cnpm/cnpmjs.org/issues/1066
+    if (name.length < 80 && pkg && pkg.time && pkg.time.unpublished && pkg.time.unpublished.time) {
       unpublishedInfo = pkg.time.unpublished;
     } else {
       pkg = null;


### PR DESCRIPTION
closes https://github.com/cnpm/cnpmjs.org/issues/1066

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cnpm/cnpmjs.org/1067)
<!-- Reviewable:end -->
