### PR TITLE
修改支持_readme.md定制覆盖

### DIFF
--- a/servers/web.js
+++ b/servers/web.js
@@ -66,12 +66,12 @@ var layout = fs.readFileSync(path.join(viewDir, 'layout.html'), 'utf8')
 fs.writeFileSync(layoutFile, layout);
 
 // custom web readme home page support
-var readmeFile = path.join(docDir, '_readme.md');
+var readmeFile = path.join(docDir, 'readme.md');
 var readmeContent;
 if (config.customReadmeFile) {
   readmeContent = fs.readFileSync(config.customReadmeFile, 'utf8');
 } else {
-  readmeContent = fs.readFileSync(path.join(docDir, 'readme.md'), 'utf8');
+  readmeContent = fs.readFileSync(path.join(docDir, '_readme.md'), 'utf8');
 }
 fs.writeFileSync(readmeFile, readmeContent);
 
@@ -81,7 +81,7 @@ app.use(markdownMiddleware({
   layout: layoutFile,
   titleHolder: '<%= locals.title %>',
   bodyHolder: '<%- locals.body %>',
-  indexName: '_readme',
+  indexName: 'readme',
   cache: true,
   render: function (content) {
     return renderMarkdown(content, false);


### PR DESCRIPTION
`_readme.md` 是排除在不受控，定位是用于用户自定义覆盖的

目前只能去修改受控 `readme.md` 才能自定义页面展示，这里逻辑应该通过 `_layout.html` 和 `layout.html` 的关系

`_readme.md` 是用于用户自定义的，用于覆盖受控的 `readme.md`