### PR TITLE
fix sync error when modules metadata contains emoji chars

### DIFF
--- a/services/package.js
+++ b/services/package.js
@@ -332,11 +332,7 @@ exports.listModuleAbbreviatedsByName = function* (name) {
   });
 
   for (var row of rows) {
-    row.package = JSON.parse(row.package);
-    if (row.publish_time && typeof row.publish_time === 'string') {
-      // pg bigint is string
-      row.publish_time = Number(row.publish_time);
-    }
+    parseRow(row);
   }
   return rows;
 };
@@ -368,7 +364,7 @@ exports.saveModuleAbbreviated = function* (mod) {
     });
   }
   item.publish_time = publish_time;
-  item.package = pkg;
+  item.package = encodeURIComponent(pkg);
 
   if (item.changed()) {
     item = yield item.save();
@@ -409,14 +405,15 @@ exports.updateModuleAbbreviatedPackage = function* (item) {
   if (!mod) {
     return null;
   }
-  var pkg = JSON.parse(mod.package);
+  parseRow(mod);
+  var pkg = mod.package;
   for (var key in item) {
     if (key === 'name' || key === 'version' || key === 'id') {
       continue;
     }
     pkg[key] = item[key];
   }
-  mod.package = JSON.stringify(pkg);
+  mod.package = encodeURIComponent( JSON.stringify(pkg) );
 
   return yield mod.save([ 'package' ]);
 };

--- a/test/services/package.test.js
+++ b/test/services/package.test.js
@@ -17,6 +17,9 @@
 var should = require('should');
 var sleep = require('co-sleep');
 var Package = require('../../services/package');
+var models = require('../../models');
+var thunkify = require('thunkify-wrap');
+var SyncModuleWorker = require('../../controllers/sync_module_worker');
 var utils = require('../utils');
 
 describe('test/services/package.test.js', function () {
@@ -581,6 +584,31 @@ describe('test/services/package.test.js', function () {
       users.should.eql([]);
       names = yield Package.listUserStarModuleNames('addStar-user');
       names.should.eql([]);
+    });
+  });
+
+  describe('updateModuleAbbreviatedPackage()', function () {
+    it('should return null if module abbreviated is not exists', function* () {
+      var mod = yield Package.updateModuleAbbreviatedPackage({
+        name: 'not-exists-module-name',
+        version: 'not-exists-module-version'
+      });
+      should.not.exist(mod);
+    });
+
+    it('should return updated module abbreviated instance', function* () {
+      var row = yield createModule('test-updateModuleAbbreviatedPackage-module-name', '1.0.0');
+      var item = {
+        id: row.package._id,
+        name: row.name,
+        version: row.version,
+        _hasShrinkwrap: true
+      };
+
+      var mod = yield Package.updateModuleAbbreviatedPackage(item);
+      Package.parseRow(mod);
+      (mod.package._hasShrinkwrap === item._hasShrinkwrap).should.be.true();
+      console.log('assert done');
     });
   });
 });


### PR DESCRIPTION
Some modules which metadata contains emoji chars (e.g. babel-preset-es2015) will cause sync error because mysql character set. `encodeURIComponent` before insert into datastore can prevent this error, refer [commit db79bd15](https://github.com/cnpm/cnpmjs.org/commit/db79bd15517f64cd86b5720ba512e23c48f39235) by @fengmk2 

fix [#1276](https://github.com/cnpm/cnpmjs.org/issues/1276)