### PR TITLE
feat: can config to not sync deleted versions

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -197,6 +197,8 @@ var config = {
 
   // sync devDependencies or not, default is false
   syncDevDependencies: false,
+  // try to remove all deleted versions from original registry
+  syncDeletedVersions: true,
 
   // changes streaming sync
   syncChangesStream: false,


### PR DESCRIPTION
avoid https://github.com/npm/registry/issues/255 again