### PR TITLE
fix: support httpProxy with basicAuth

### DIFF
--- a/common/urllib.js
+++ b/common/urllib.js
@@ -30,26 +30,30 @@ if (config.httpProxy) {
     httpAgent = tunnel.httpOverHttp({
       proxy: {
         host: urlinfo.hostname,
-        port: urlinfo.port
+        port: urlinfo.port,
+        proxyAuth: urlinfo.auth
       }
     });
     httpsAgent = tunnel.httpsOverHttp({
       proxy: {
         host: urlinfo.hostname,
-        port: urlinfo.port
+        port: urlinfo.port,
+        proxyAuth: urlinfo.auth
       }
     });
   } else if (urlinfo.protocol === 'https:') {
     httpAgent = tunnel.httpOverHttps({
       proxy: {
         host: urlinfo.hostname,
-        port: urlinfo.port
+        port: urlinfo.port,
+        proxyAuth: urlinfo.auth
       }
     });
     httpsAgent = tunnel.httpsOverHttps({
       proxy: {
         host: urlinfo.hostname,
-        port: urlinfo.port
+        port: urlinfo.port,
+        proxyAuth: urlinfo.auth
       }
     });
   } else {


### PR DESCRIPTION
When building my private cnpm registry，I have to connect to the public npm registry using http-proxy. But the `httpProxy`  configure doesn't work well since the proxy url contains the BasicAuth info, such as `http://username:password@ip:port`.

The PR will brings:

- Support `httpProxy` configure with BasicAuth info
- closed #742 #1209

I have test this PR in my environment by requesting `/sync/mkdirp#logid=11` successfully, and I hope this PR won't cause issues with your project.

@fengmk2 