### PR TITLE
refactor: normalize database structure

### DIFF
--- a/docs/db.sql
+++ b/docs/db.sql
@@ -3,82 +3,116 @@ CREATE TABLE IF NOT EXISTS `user` (
  `gmt_create` datetime NOT NULL COMMENT 'create time',
  `gmt_modified` datetime NOT NULL COMMENT 'modified time',
  `name` varchar(100) NOT NULL COMMENT 'user name',
- `salt` varchar(100) NOT NULL,
+ `salt` varchar(100) NOT NULL COMMENT 'user salt',
  `password_sha` varchar(100) NOT NULL COMMENT 'user password hash',
  `ip` varchar(64) NOT NULL COMMENT 'user last request ip',
- `roles` varchar(200) NOT NULL DEFAULT '[]',
- `rev` varchar(40) NOT NULL,
- `email` varchar(400) NOT NULL,
+ `roles` varchar(200) NOT NULL DEFAULT '[]' COMMENT 'user roles',
+ `rev` varchar(40) NOT NULL COMMENT 'user rev',
+ `email` varchar(400) NOT NULL COMMENT 'user email',
  `json` longtext CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci COMMENT 'json details',
  `npm_user` tinyint(1) DEFAULT '0' COMMENT 'user sync from npm or not, 1: true, other: false',
  PRIMARY KEY (`id`),
- UNIQUE KEY `name` (`name`),
- KEY `gmt_modified` (`gmt_modified`)
+ UNIQUE KEY `uk_name` (`name`),
+ KEY `idx_gmt_modified` (`gmt_modified`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COMMENT='user base info';
 -- ALTER TABLE `user`
 --   ADD `json` longtext CHARACTER SET utf8 COLLATE utf8_general_ci COMMENT 'json details',
 --   ADD `npm_user` tinyint(1) DEFAULT '0' COMMENT 'user sync from npm or not, 1: true, other: false';
 -- ALTER TABLE `user` CHANGE `json` `json` longtext CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci COMMENT 'json details';
+-- ALTER TABLE `user`
+--   CHANGE `salt` `salt` varchar(100) NOT NULL COMMENT 'user salt',
+--   CHANGE `roles` `roles` varchar(200) NOT NULL DEFAULT '[]' COMMENT 'user roles',
+--   CHANGE `rev` `rev` varchar(40) NOT NULL COMMENT 'user rev',
+--   CHANGE `email` `email` varchar(400) NOT NULL COMMENT 'user email',
+--   DROP KEY `name`,
+--   DROP KEY `gmt_modified`,
+--   ADD UNIQUE KEY `uk_name` (`name`),
+--   ADD KEY `idx_gmt_modified` (`gmt_modified`);
 
 CREATE TABLE IF NOT EXISTS `module_keyword` (
  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT COMMENT 'primary key',
  `gmt_create` datetime NOT NULL COMMENT 'create time',
  `keyword` varchar(100) CHARACTER SET utf8 COLLATE utf8_general_ci NOT NULL COMMENT 'keyword',
- `name` varchar(100) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL COMMENT 'module name',
- `description` longtext,
+ `name` varchar(214) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL COMMENT 'module name',
+ `description` longtext COMMENT 'module description',
  PRIMARY KEY (`id`),
- UNIQUE KEY `keyword_module_name` (`keyword`,`name`),
- KEY `name` (`name`)
+ UNIQUE KEY `uk_keyword_module_name` (`keyword`,`name`),
+ KEY `idx_name` (`name`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COMMENT='module keyword';
+-- ALTER TABLE `module_keyword`
+--   CHANGE `name` `name` varchar(214) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL COMMENT 'module name',
+--   CHANGE `description` `description` longtext COMMENT 'module description',
+--   DROP KEY `keyword_module_name`,
+--   DROP KEY `name`,
+--   ADD UNIQUE KEY `uk_keyword_module_name` (`keyword`, `name`),
+--   ADD KEY `idx_name` (`name`);
 
 CREATE TABLE IF NOT EXISTS `module_star` (
  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT COMMENT 'primary key',
  `gmt_create` datetime NOT NULL COMMENT 'create time',
  `user` varchar(100) CHARACTER SET utf8 COLLATE utf8_general_ci NOT NULL COMMENT 'user name',
- `name` varchar(100) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL COMMENT 'module name',
+ `name` varchar(214) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL COMMENT 'module name',
  PRIMARY KEY (`id`),
- UNIQUE KEY `user_module_name` (`user`,`name`),
- KEY `name` (`name`)
+ UNIQUE KEY `uk_user_module_name` (`user`,`name`),
+ KEY `idx_name` (`name`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COMMENT='module star';
+-- ALTER TABLE `module_star`
+--   CHANGE `name` `name` varchar(214) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL COMMENT 'module name',
+--   DROP KEY `user_module_name`,
+--   DROP KEY `name`,
+--   ADD UNIQUE KEY `uk_user_module_name` (`user`, `name`),
+--   ADD KEY `idx_name` (`name`);
 
 CREATE TABLE IF NOT EXISTS `module_maintainer` (
  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT COMMENT 'primary key',
  `gmt_create` datetime NOT NULL COMMENT 'create time',
  `user` varchar(100) CHARACTER SET utf8 COLLATE utf8_general_ci NOT NULL COMMENT 'user name',
- `name` varchar(100) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL COMMENT 'module name',
+ `name` varchar(214) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL COMMENT 'module name',
  PRIMARY KEY (`id`),
- UNIQUE KEY `user_module_name` (`user`,`name`),
- KEY `name` (`name`)
+ UNIQUE KEY `uk_user_module_name` (`user`,`name`),
+ KEY `idx_name` (`name`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COMMENT='private module maintainers';
+-- ALTER TABLE `module_maintainer`
+--   CHANGE `name` `name` varchar(214) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL COMMENT 'module name',
+--   DROP KEY `user_module_name`,
+--   DROP KEY `name`,
+--   ADD UNIQUE KEY `uk_user_module_name` (`user`, `name`),
+--   ADD KEY `idx_name` (`name`);
 
 CREATE TABLE IF NOT EXISTS `npm_module_maintainer` (
  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT COMMENT 'primary key',
  `gmt_create` datetime NOT NULL COMMENT 'create time',
  `user` varchar(100) CHARACTER SET utf8 COLLATE utf8_general_ci NOT NULL COMMENT 'user name',
- `name` varchar(100) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL COMMENT 'module name',
+ `name` varchar(214) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL COMMENT 'module name',
  PRIMARY KEY (`id`),
- UNIQUE KEY `user_module_name` (`user`,`name`),
- KEY `name` (`name`)
+ UNIQUE KEY `uk_user_module_name` (`user`,`name`),
+ KEY `idx_name` (`name`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COMMENT='npm original module maintainers';
+-- ALTER TABLE `npm_module_maintainer`
+--   CHANGE `name` `name` varchar(214) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL COMMENT 'module name',
+--   DROP KEY `user_module_name`,
+--   DROP KEY `name`,
+--   ADD UNIQUE KEY `uk_user_module_name` (`user`, `name`),
+--   ADD KEY `idx_name` (`name`);
 
 CREATE TABLE IF NOT EXISTS `module` (
  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT COMMENT 'primary key',
  `gmt_create` datetime NOT NULL COMMENT 'create time',
  `gmt_modified` datetime NOT NULL COMMENT 'modified time',
- `author` varchar(100) NOT NULL,
- `name` varchar(100) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL COMMENT 'module name',
+ `author` varchar(100) NOT NULL COMMENT 'module author',
+ `name` varchar(214) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL COMMENT 'module name',
  `version` varchar(30) NOT NULL COMMENT 'module version',
- `description` longtext,
+ `description` longtext COMMENT 'module description',
  `package` longtext CHARACTER SET utf8 COLLATE utf8_general_ci COMMENT 'package.json',
- `dist_shasum` varchar(100) DEFAULT NULL,
- `dist_tarball` varchar(2048) DEFAULT NULL,
- `dist_size` int(10) unsigned NOT NULL DEFAULT '0',
- `publish_time` bigint(20) unsigned,
+ `dist_shasum` varchar(100) DEFAULT NULL COMMENT 'module dist SHASUM',
+ `dist_tarball` varchar(2048) DEFAULT NULL COMMENT 'module dist tarball',
+ `dist_size` int(10) unsigned NOT NULL DEFAULT '0' COMMENT 'module dist size',
+ `publish_time` bigint(20) unsigned COMMENT 'module publish time',
  PRIMARY KEY (`id`),
- UNIQUE KEY `name` (`name`,`version`),
- KEY `gmt_modified` (`gmt_modified`),
- KEY `publish_time` (`publish_time`),
- KEY `author` (`author`)
+ UNIQUE KEY `uk_name` (`name`,`version`),
+ KEY `idx_gmt_modified` (`gmt_modified`),
+ KEY `idx_publish_time` (`publish_time`),
+ KEY `idx_author` (`author`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COMMENT='module info';
 -- ALTER TABLE `module` ADD `description` longtext;
 -- ALTER TABLE `module` ADD `publish_time` bigint(20) unsigned, ADD KEY `publish_time` (`publish_time`);
@@ -86,74 +120,125 @@ CREATE TABLE IF NOT EXISTS `module` (
 -- ALTER TABLE `module` CHANGE `description` `description` LONGTEXT CHARACTER SET utf8 COLLATE utf8_general_ci;
 -- show create table module\G
 -- ALTER TABLE  `module` CHANGE  `name`  `name` VARCHAR( 100 ) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL COMMENT  'module name';
+-- ALTER TABLE `module`
+--   CHANGE `author` `author` varchar(100) NOT NULL COMMENT 'module author',
+--   CHANGE `name` `name` varchar(214) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL COMMENT 'module name',
+--   CHANGE `version` `version` varchar(30) NOT NULL COMMENT 'module version',
+--   CHANGE `description` `description` longtext COMMENT 'module description',
+--   CHANGE `package` `package` longtext CHARACTER SET utf8 COLLATE utf8_general_ci COMMENT 'package.json',
+--   CHANGE `dist_shasum` `dist_shasum` varchar(100) DEFAULT NULL COMMENT 'module dist SHASUM',
+--   CHANGE `dist_tarball` `dist_tarball` varchar(2048) DEFAULT NULL COMMENT 'module dist tarball',
+--   CHANGE `dist_size` `dist_size` int(10) unsigned NOT NULL DEFAULT '0' COMMENT 'module dist size',
+--   CHANGE `publish_time` `publish_time` bigint(20) unsigned COMMENT 'module publish time',
+--   DROP KEY `gmt_modified`,
+--   DROP KEY `name`,
+--   DROP KEY `publish_time`,
+--   DROP KEY `author`,
+--   ADD UNIQUE KEY `uk_name` (`name`, `version`),
+--   ADD KEY `idx_gmt_modified` (`gmt_modified`),
+--   ADD KEY `idx_publish_time` (`publish_time`),
+--   ADD KEY `idx_author` (`author`);
 
 CREATE TABLE IF NOT EXISTS `module_abbreviated` (
  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT COMMENT 'primary key',
  `gmt_create` datetime NOT NULL COMMENT 'create time',
  `gmt_modified` datetime NOT NULL COMMENT 'modified time',
- `name` varchar(100) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL COMMENT 'module name',
+ `name` varchar(214) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL COMMENT 'module name',
  `version` varchar(30) NOT NULL COMMENT 'module version',
  `package` longtext CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci COMMENT 'the abbreviated metadata',
- `publish_time` bigint(20) unsigned,
+ `publish_time` bigint(20) unsigned COMMENT 'the publish time',
  PRIMARY KEY (`id`),
- UNIQUE KEY `name` (`name`,`version`),
- KEY `gmt_modified` (`gmt_modified`),
- KEY `publish_time` (`publish_time`)
+ UNIQUE KEY `uk_name` (`name`,`version`),
+ KEY `idx_gmt_modified` (`gmt_modified`),
+ KEY `idx_publish_time` (`publish_time`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COMMENT='module abbreviated info';
+-- ALTER TABLE `module_abbreviated`
+--   CHANGE `name` `name` varchar(214) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL COMMENT 'module name',
+--   CHANGE `publish_time` `publish_time` bigint(20) unsigned COMMENT 'the publish time',
+--   DROP KEY `name`,
+--   DROP KEY `gmt_modified`,
+--   DROP KEY `publish_time`,
+--   ADD UNIQUE KEY `uk_name` (`name`, `version`),
+--   ADD KEY `idx_gmt_modified` (`gmt_modified`),
+--   ADD KEY `idx_publish_time` (`publish_time`);
 
 CREATE TABLE IF NOT EXISTS `package_readme` (
  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT COMMENT 'primary key',
  `gmt_create` datetime NOT NULL COMMENT 'create time',
  `gmt_modified` datetime NOT NULL COMMENT 'modified time',
- `name` varchar(100) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL COMMENT 'module name',
+ `name` varchar(214) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL COMMENT 'module name',
  `readme` longtext CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci COMMENT 'the latest version readme',
  `version` varchar(30) NOT NULL COMMENT 'module version',
  PRIMARY KEY (`id`),
- UNIQUE KEY `name` (`name`),
- KEY `gmt_modified` (`gmt_modified`)
+ UNIQUE KEY `uk_name` (`name`),
+ KEY `idx_gmt_modified` (`gmt_modified`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COMMENT='package latest readme';
+-- ALTER TABLE `package_readme`
+--   CHANGE `name` `name` varchar(214) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL COMMENT 'module name',
+--   DROP KEY `name`,
+--   DROP KEY `gmt_modified`,
+--   ADD UNIQUE KEY `uk_name` (`name`),
+--   ADD KEY `idx_gmt_modified` (`gmt_modified`);
 
 CREATE TABLE IF NOT EXISTS `module_log` (
  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT COMMENT 'primary key',
  `gmt_create` datetime NOT NULL COMMENT 'create time',
  `gmt_modified` datetime NOT NULL COMMENT 'modified time',
- `username` varchar(100) NOT NULL,
- `name` varchar(100) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL COMMENT 'module name',
- `log` longtext,
+ `username` varchar(100) NOT NULL COMMENT 'which username',
+ `name` varchar(214) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL COMMENT 'module name',
+ `log` longtext COMMENT 'the raw log',
  PRIMARY KEY (`id`),
- KEY `name` (`name`)
+ KEY `idx_name` (`name`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COMMENT='module sync log';
 -- ALTER TABLE  `module_log` CHANGE  `name`  `name` VARCHAR( 100 ) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL COMMENT  'module name';
+-- ALTER TABLE `module_log`
+--   CHANGE `username` `username` varchar(100) NOT NULL COMMENT 'which username',
+--   CHANGE `name` `name` varchar(214) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL COMMENT 'module name',
+--   CHANGE `log` `log` longtext COMMENT 'the raw log',
+--   DROP KEY `name`,
+--   ADD KEY `idx_name` (`name`);
 
 CREATE TABLE IF NOT EXISTS `tag` (
  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT COMMENT 'primary key',
  `gmt_create` datetime NOT NULL COMMENT 'create time',
  `gmt_modified` datetime NOT NULL COMMENT 'modified time',
- `name` varchar(100) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL COMMENT 'module name',
+ `name` varchar(214) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL COMMENT 'module name',
  `tag` varchar(30) NOT NULL COMMENT 'tag name',
  `version` varchar(30) NOT NULL COMMENT 'module version',
  `module_id` bigint(20) unsigned NOT NULL COMMENT 'module id',
  PRIMARY KEY (`id`),
- UNIQUE KEY `name` (`name`, `tag`),
- KEY `gmt_modified` (`gmt_modified`)
+ UNIQUE KEY `uk_name` (`name`, `tag`),
+ KEY `idx_gmt_modified` (`gmt_modified`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COMMENT='module tag';
 -- ALTER TABLE  `tag` ADD  `module_id` BIGINT( 20 ) UNSIGNED NOT NULL;
 -- ALTER TABLE  `tag` CHANGE  `name`  `name` VARCHAR( 100 ) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL COMMENT  'module name';
 -- ALTER TABLE `tag` ADD KEY `gmt_modified` (`gmt_modified`);
+-- ALTER TABLE `tag`
+--   CHANGE `name` `name` varchar(214) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL COMMENT 'module name',
+--   DROP KEY `name`,
+--   DROP KEY `gmt_modified`,
+--   ADD UNIQUE KEY `uk_name` (`name`, `tag`),
+--   ADD KEY `idx_gmt_modified` (`gmt_modified`);
 
 CREATE TABLE IF NOT EXISTS `module_unpublished` (
  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT COMMENT 'primary key',
  `gmt_create` datetime NOT NULL COMMENT 'create time',
  `gmt_modified` datetime NOT NULL COMMENT 'modified time',
- `name` varchar(100) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL COMMENT 'module name',
+ `name` varchar(214) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL COMMENT 'module name',
  `package` longtext CHARACTER SET utf8 COLLATE utf8_general_ci COMMENT 'base info: tags, time, maintainers, description, versions',
  PRIMARY KEY (`id`),
- UNIQUE KEY `name` (`name`),
- KEY `gmt_modified` (`gmt_modified`)
+ UNIQUE KEY `uk_name` (`name`),
+ KEY `idx_gmt_modified` (`gmt_modified`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COMMENT='module unpublished info';
+-- ALTER TABLE `module_unpublished`
+--   CHANGE `name` `name` varchar(214) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL COMMENT 'module name',
+--   DROP KEY `name`,
+--   DROP KEY `gmt_modified`,
+--   ADD UNIQUE KEY `uk_name` (`name`),
+--   ADD KEY `idx_gmt_modified` (`gmt_modified`);
 
 CREATE TABLE IF NOT EXISTS `total` (
- `name` varchar(100) NOT NULL COMMENT 'total name',
+ `name` varchar(214) NOT NULL COMMENT 'total name',
  `gmt_modified` datetime NOT NULL COMMENT 'modified time',
  `module_delete` bigint(20) unsigned NOT NULL DEFAULT '0' COMMENT 'module delete count',
  `last_sync_time` bigint(20) unsigned NOT NULL DEFAULT '0' COMMENT 'last timestamp sync from official registry',
@@ -177,6 +262,7 @@ INSERT INTO total(name, gmt_modified) VALUES('total', now())
 -- ALTER TABLE `total` ADD `fail_sync_num` int unsigned NOT NULL DEFAULT '0' COMMENT 'how many packages sync fail at this time'
 -- ALTER TABLE `total` ADD `left_sync_num` int unsigned NOT NULL DEFAULT '0' COMMENT 'how many packages left to be sync'
 -- ALTER TABLE `total` ADD `last_sync_module` varchar(100) NOT NULL COMMENT 'last sync success module name';
+-- ALTER TABLE `total` CHANGE `name` `name` varchar(214) NOT NULL COMMENT 'total name';
 
 -- CREATE TABLE IF NOT EXISTS `download_total` (
 --  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT COMMENT 'primary key',
@@ -195,7 +281,7 @@ CREATE TABLE IF NOT EXISTS `downloads` (
   `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT COMMENT 'primary key',
   `gmt_create` datetime NOT NULL COMMENT 'create time',
   `gmt_modified` datetime NOT NULL COMMENT 'modified time',
-  `name` varchar(100) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL COMMENT 'module name',
+  `name` varchar(214) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL COMMENT 'module name',
   `date` int unsigned NOT NULL COMMENT 'YYYYMM format',
   `d01` bigint(20) unsigned NOT NULL DEFAULT '0' COMMENT '01 download count',
   `d02` bigint(20) unsigned NOT NULL DEFAULT '0' COMMENT '02 download count',
@@ -229,43 +315,70 @@ CREATE TABLE IF NOT EXISTS `downloads` (
   `d30` bigint(20) unsigned NOT NULL DEFAULT '0' COMMENT '30 download count',
   `d31` bigint(20) unsigned NOT NULL DEFAULT '0' COMMENT '31 download count',
   PRIMARY KEY (`id`),
-  UNIQUE KEY `name_date` (`name`, `date`),
-  KEY `date` (`date`)
+  UNIQUE KEY `uk_name_date` (`name`, `date`),
+  KEY `idx_date` (`date`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COMMENT='module download total info';
+-- ALTER TABLE `downloads`
+--   CHANGE `name` `name` varchar(214) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL COMMENT 'module name',
+--   DROP KEY `name_date`,
+--   DROP KEY `date`,
+--   ADD UNIQUE KEY `uk_name_date` (`name`, `date`),
+--   ADD KEY `idx_date` (`date`);
 
 CREATE TABLE IF NOT EXISTS `module_deps` (
  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT COMMENT 'primary key',
  `gmt_create` datetime NOT NULL COMMENT 'create time',
- `name` varchar(100) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL COMMENT 'module name',
- `deps` varchar(100) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL COMMENT 'which module depend on this module',
+ `name` varchar(214) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL COMMENT 'module name',
+ `deps` varchar(214) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL COMMENT 'which module depend on this module',
  PRIMARY KEY (`id`),
- UNIQUE KEY `name_deps` (`name`,`deps`),
- KEY `name` (`name`)
+ UNIQUE KEY `uk_name_deps` (`name`,`deps`),
+ KEY `idx_name` (`name`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COMMENT='module deps';
+-- ALTER TABLE `module_deps`
+--   CHANGE `name` `name` varchar(214) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL COMMENT 'module name',
+--   CHANGE `deps` `deps` varchar(214) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL COMMENT 'which module depend on this module',
+--   DROP KEY `name_deps`,
+--   DROP KEY `name`,
+--   ADD UNIQUE KEY `uk_name_deps` (`name`, `deps`),
+--   ADD KEY `idx_name` (`name`);
 
 CREATE TABLE IF NOT EXISTS `dist_dir` (
  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT COMMENT 'primary key',
  `gmt_create` datetime NOT NULL COMMENT 'create time',
  `gmt_modified` datetime NOT NULL COMMENT 'modified time',
- `name` varchar(200) NOT NULL COMMENT 'dir name',
- `parent` varchar(200) NOT NULL COMMENT 'parent dir' DEFAULT '/',
+ `name` varchar(214) NOT NULL COMMENT 'dir name',
+ `parent` varchar(214) NOT NULL COMMENT 'parent dir' DEFAULT '/',
  `date` varchar(20) COMMENT '02-May-2014 01:06',
  PRIMARY KEY (`id`),
- UNIQUE KEY `name` (`parent`, `name`),
- KEY `gmt_modified` (`gmt_modified`)
+ UNIQUE KEY `uk_name` (`parent`, `name`),
+ KEY `idx_gmt_modified` (`gmt_modified`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COMMENT='dist dir info';
+-- ALTER TABLE `dist_dir`
+--   CHANGE `name` `name` varchar(214) NOT NULL COMMENT 'dir name',
+--   CHANGE `parent` `parent` varchar(214) NOT NULL COMMENT 'parent dir' DEFAULT '/',
+--   DROP KEY `name`,
+--   DROP KEY `gmt_modified`,
+--   ADD UNIQUE KEY `uk_name` (`parent`, `name`),
+--   ADD KEY `idx_gmt_modified` (`gmt_modified`);
 
 CREATE TABLE IF NOT EXISTS `dist_file` (
  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT COMMENT 'primary key',
  `gmt_create` datetime NOT NULL COMMENT 'create time',
  `gmt_modified` datetime NOT NULL COMMENT 'modified time',
- `name` varchar(100) NOT NULL COMMENT 'file name',
- `parent` varchar(200) NOT NULL COMMENT 'parent dir' DEFAULT '/',
+ `name` varchar(214) NOT NULL COMMENT 'file name',
+ `parent` varchar(214) NOT NULL COMMENT 'parent dir' DEFAULT '/',
  `date` varchar(20) COMMENT '02-May-2014 01:06',
  `size` int(10) unsigned NOT NULL COMMENT 'file size' DEFAULT '0',
  `sha1` varchar(40) COMMENT 'sha1 hex value',
  `url` varchar(2048),
  PRIMARY KEY (`id`),
- UNIQUE KEY `fullname` (`parent`, `name`),
- KEY `gmt_modified` (`gmt_modified`)
+ UNIQUE KEY `uk_fullname` (`parent`, `name`),
+ KEY `idx_gmt_modified` (`gmt_modified`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COMMENT='dist file info';
+-- ALTER TABLE `dist_file`
+--   CHANGE `name` `name` varchar(214) NOT NULL COMMENT 'file name',
+--   CHANGE `parent` `parent` varchar(214) NOT NULL COMMENT 'parent dir' DEFAULT '/',
+--   DROP KEY `fullname`,
+--   DROP KEY `gmt_modified`,
+--   ADD UNIQUE KEY `uk_fullname` (`parent`, `name`),
+--   ADD KEY `idx_gmt_modified` (`gmt_modified`);

--- a/docs/db.sql
+++ b/docs/db.sql
@@ -23,11 +23,7 @@ CREATE TABLE IF NOT EXISTS `user` (
 --   CHANGE `salt` `salt` varchar(100) NOT NULL COMMENT 'user salt',
 --   CHANGE `roles` `roles` varchar(200) NOT NULL DEFAULT '[]' COMMENT 'user roles',
 --   CHANGE `rev` `rev` varchar(40) NOT NULL COMMENT 'user rev',
---   CHANGE `email` `email` varchar(400) NOT NULL COMMENT 'user email',
---   DROP KEY `name`,
---   DROP KEY `gmt_modified`,
---   ADD UNIQUE KEY `uk_name` (`name`),
---   ADD KEY `idx_gmt_modified` (`gmt_modified`);
+--   CHANGE `email` `email` varchar(400) NOT NULL COMMENT 'user email';
 
 CREATE TABLE IF NOT EXISTS `module_keyword` (
  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT COMMENT 'primary key',
@@ -41,11 +37,7 @@ CREATE TABLE IF NOT EXISTS `module_keyword` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COMMENT='module keyword';
 -- ALTER TABLE `module_keyword`
 --   CHANGE `name` `name` varchar(214) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL COMMENT 'module name',
---   CHANGE `description` `description` longtext COMMENT 'module description',
---   DROP KEY `keyword_module_name`,
---   DROP KEY `name`,
---   ADD UNIQUE KEY `uk_keyword_module_name` (`keyword`, `name`),
---   ADD KEY `idx_name` (`name`);
+--   CHANGE `description` `description` longtext COMMENT 'module description';
 
 CREATE TABLE IF NOT EXISTS `module_star` (
  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT COMMENT 'primary key',
@@ -57,11 +49,7 @@ CREATE TABLE IF NOT EXISTS `module_star` (
  KEY `idx_name` (`name`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COMMENT='module star';
 -- ALTER TABLE `module_star`
---   CHANGE `name` `name` varchar(214) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL COMMENT 'module name',
---   DROP KEY `user_module_name`,
---   DROP KEY `name`,
---   ADD UNIQUE KEY `uk_user_module_name` (`user`, `name`),
---   ADD KEY `idx_name` (`name`);
+--   CHANGE `name` `name` varchar(214) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL COMMENT 'module name';
 
 CREATE TABLE IF NOT EXISTS `module_maintainer` (
  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT COMMENT 'primary key',
@@ -73,11 +61,7 @@ CREATE TABLE IF NOT EXISTS `module_maintainer` (
  KEY `idx_name` (`name`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COMMENT='private module maintainers';
 -- ALTER TABLE `module_maintainer`
---   CHANGE `name` `name` varchar(214) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL COMMENT 'module name',
---   DROP KEY `user_module_name`,
---   DROP KEY `name`,
---   ADD UNIQUE KEY `uk_user_module_name` (`user`, `name`),
---   ADD KEY `idx_name` (`name`);
+--   CHANGE `name` `name` varchar(214) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL COMMENT 'module name';
 
 CREATE TABLE IF NOT EXISTS `npm_module_maintainer` (
  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT COMMENT 'primary key',
@@ -89,11 +73,7 @@ CREATE TABLE IF NOT EXISTS `npm_module_maintainer` (
  KEY `idx_name` (`name`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COMMENT='npm original module maintainers';
 -- ALTER TABLE `npm_module_maintainer`
---   CHANGE `name` `name` varchar(214) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL COMMENT 'module name',
---   DROP KEY `user_module_name`,
---   DROP KEY `name`,
---   ADD UNIQUE KEY `uk_user_module_name` (`user`, `name`),
---   ADD KEY `idx_name` (`name`);
+--   CHANGE `name` `name` varchar(214) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL COMMENT 'module name';
 
 CREATE TABLE IF NOT EXISTS `module` (
  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT COMMENT 'primary key',
@@ -129,15 +109,7 @@ CREATE TABLE IF NOT EXISTS `module` (
 --   CHANGE `dist_shasum` `dist_shasum` varchar(100) DEFAULT NULL COMMENT 'module dist SHASUM',
 --   CHANGE `dist_tarball` `dist_tarball` varchar(2048) DEFAULT NULL COMMENT 'module dist tarball',
 --   CHANGE `dist_size` `dist_size` int(10) unsigned NOT NULL DEFAULT '0' COMMENT 'module dist size',
---   CHANGE `publish_time` `publish_time` bigint(20) unsigned COMMENT 'module publish time',
---   DROP KEY `gmt_modified`,
---   DROP KEY `name`,
---   DROP KEY `publish_time`,
---   DROP KEY `author`,
---   ADD UNIQUE KEY `uk_name` (`name`, `version`),
---   ADD KEY `idx_gmt_modified` (`gmt_modified`),
---   ADD KEY `idx_publish_time` (`publish_time`),
---   ADD KEY `idx_author` (`author`);
+--   CHANGE `publish_time` `publish_time` bigint(20) unsigned COMMENT 'module publish time';
 
 CREATE TABLE IF NOT EXISTS `module_abbreviated` (
  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT COMMENT 'primary key',
@@ -154,13 +126,7 @@ CREATE TABLE IF NOT EXISTS `module_abbreviated` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COMMENT='module abbreviated info';
 -- ALTER TABLE `module_abbreviated`
 --   CHANGE `name` `name` varchar(214) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL COMMENT 'module name',
---   CHANGE `publish_time` `publish_time` bigint(20) unsigned COMMENT 'the publish time',
---   DROP KEY `name`,
---   DROP KEY `gmt_modified`,
---   DROP KEY `publish_time`,
---   ADD UNIQUE KEY `uk_name` (`name`, `version`),
---   ADD KEY `idx_gmt_modified` (`gmt_modified`),
---   ADD KEY `idx_publish_time` (`publish_time`);
+--   CHANGE `publish_time` `publish_time` bigint(20) unsigned COMMENT 'the publish time';
 
 CREATE TABLE IF NOT EXISTS `package_readme` (
  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT COMMENT 'primary key',
@@ -174,11 +140,7 @@ CREATE TABLE IF NOT EXISTS `package_readme` (
  KEY `idx_gmt_modified` (`gmt_modified`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COMMENT='package latest readme';
 -- ALTER TABLE `package_readme`
---   CHANGE `name` `name` varchar(214) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL COMMENT 'module name',
---   DROP KEY `name`,
---   DROP KEY `gmt_modified`,
---   ADD UNIQUE KEY `uk_name` (`name`),
---   ADD KEY `idx_gmt_modified` (`gmt_modified`);
+--   CHANGE `name` `name` varchar(214) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL COMMENT 'module name';
 
 CREATE TABLE IF NOT EXISTS `module_log` (
  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT COMMENT 'primary key',
@@ -194,9 +156,7 @@ CREATE TABLE IF NOT EXISTS `module_log` (
 -- ALTER TABLE `module_log`
 --   CHANGE `username` `username` varchar(100) NOT NULL COMMENT 'which username',
 --   CHANGE `name` `name` varchar(214) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL COMMENT 'module name',
---   CHANGE `log` `log` longtext COMMENT 'the raw log',
---   DROP KEY `name`,
---   ADD KEY `idx_name` (`name`);
+--   CHANGE `log` `log` longtext COMMENT 'the raw log';
 
 CREATE TABLE IF NOT EXISTS `tag` (
  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT COMMENT 'primary key',
@@ -214,11 +174,7 @@ CREATE TABLE IF NOT EXISTS `tag` (
 -- ALTER TABLE  `tag` CHANGE  `name`  `name` VARCHAR( 100 ) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL COMMENT  'module name';
 -- ALTER TABLE `tag` ADD KEY `gmt_modified` (`gmt_modified`);
 -- ALTER TABLE `tag`
---   CHANGE `name` `name` varchar(214) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL COMMENT 'module name',
---   DROP KEY `name`,
---   DROP KEY `gmt_modified`,
---   ADD UNIQUE KEY `uk_name` (`name`, `tag`),
---   ADD KEY `idx_gmt_modified` (`gmt_modified`);
+--   CHANGE `name` `name` varchar(214) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL COMMENT 'module name';
 
 CREATE TABLE IF NOT EXISTS `module_unpublished` (
  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT COMMENT 'primary key',
@@ -231,11 +187,7 @@ CREATE TABLE IF NOT EXISTS `module_unpublished` (
  KEY `idx_gmt_modified` (`gmt_modified`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COMMENT='module unpublished info';
 -- ALTER TABLE `module_unpublished`
---   CHANGE `name` `name` varchar(214) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL COMMENT 'module name',
---   DROP KEY `name`,
---   DROP KEY `gmt_modified`,
---   ADD UNIQUE KEY `uk_name` (`name`),
---   ADD KEY `idx_gmt_modified` (`gmt_modified`);
+--   CHANGE `name` `name` varchar(214) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL COMMENT 'module name';
 
 CREATE TABLE IF NOT EXISTS `total` (
  `name` varchar(214) NOT NULL COMMENT 'total name',
@@ -319,11 +271,7 @@ CREATE TABLE IF NOT EXISTS `downloads` (
   KEY `idx_date` (`date`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COMMENT='module download total info';
 -- ALTER TABLE `downloads`
---   CHANGE `name` `name` varchar(214) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL COMMENT 'module name',
---   DROP KEY `name_date`,
---   DROP KEY `date`,
---   ADD UNIQUE KEY `uk_name_date` (`name`, `date`),
---   ADD KEY `idx_date` (`date`);
+--   CHANGE `name` `name` varchar(214) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL COMMENT 'module name';
 
 CREATE TABLE IF NOT EXISTS `module_deps` (
  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT COMMENT 'primary key',
@@ -336,11 +284,7 @@ CREATE TABLE IF NOT EXISTS `module_deps` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COMMENT='module deps';
 -- ALTER TABLE `module_deps`
 --   CHANGE `name` `name` varchar(214) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL COMMENT 'module name',
---   CHANGE `deps` `deps` varchar(214) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL COMMENT 'which module depend on this module',
---   DROP KEY `name_deps`,
---   DROP KEY `name`,
---   ADD UNIQUE KEY `uk_name_deps` (`name`, `deps`),
---   ADD KEY `idx_name` (`name`);
+--   CHANGE `deps` `deps` varchar(214) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL COMMENT 'which module depend on this module';
 
 CREATE TABLE IF NOT EXISTS `dist_dir` (
  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT COMMENT 'primary key',
@@ -355,11 +299,7 @@ CREATE TABLE IF NOT EXISTS `dist_dir` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COMMENT='dist dir info';
 -- ALTER TABLE `dist_dir`
 --   CHANGE `name` `name` varchar(214) NOT NULL COMMENT 'dir name',
---   CHANGE `parent` `parent` varchar(214) NOT NULL COMMENT 'parent dir' DEFAULT '/',
---   DROP KEY `name`,
---   DROP KEY `gmt_modified`,
---   ADD UNIQUE KEY `uk_name` (`parent`, `name`),
---   ADD KEY `idx_gmt_modified` (`gmt_modified`);
+--   CHANGE `parent` `parent` varchar(214) NOT NULL COMMENT 'parent dir' DEFAULT '/';
 
 CREATE TABLE IF NOT EXISTS `dist_file` (
  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT COMMENT 'primary key',
@@ -377,8 +317,4 @@ CREATE TABLE IF NOT EXISTS `dist_file` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COMMENT='dist file info';
 -- ALTER TABLE `dist_file`
 --   CHANGE `name` `name` varchar(214) NOT NULL COMMENT 'file name',
---   CHANGE `parent` `parent` varchar(214) NOT NULL COMMENT 'parent dir' DEFAULT '/',
---   DROP KEY `fullname`,
---   DROP KEY `gmt_modified`,
---   ADD UNIQUE KEY `uk_fullname` (`parent`, `name`),
---   ADD KEY `idx_gmt_modified` (`gmt_modified`);
+--   CHANGE `parent` `parent` varchar(214) NOT NULL COMMENT 'parent dir' DEFAULT '/';

--- a/models/download_total.js
+++ b/models/download_total.js
@@ -18,7 +18,7 @@
 //  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT COMMENT 'primary key',
 //  `gmt_create` datetime NOT NULL COMMENT 'create time',
 //  `gmt_modified` datetime NOT NULL COMMENT 'modified time',
-//  `name` varchar(100) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL COMMENT 'module name',
+//  `name` varchar(214) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL COMMENT 'module name',
 //  `date` int unsigned NOT NULL COMMENT 'YYYYMM format',
 //  `d01` bigint(20) unsigned NOT NULL DEFAULT '0' COMMENT '01 download count',
 //  `d02` bigint(20) unsigned NOT NULL DEFAULT '0' COMMENT '02 download count',
@@ -52,14 +52,14 @@
 //  `d30` bigint(20) unsigned NOT NULL DEFAULT '0' COMMENT '30 download count',
 //  `d31` bigint(20) unsigned NOT NULL DEFAULT '0' COMMENT '31 download count',
 //  PRIMARY KEY (`id`),
-//  UNIQUE KEY `name_date` (`name`, `date`)
-//  KEY `date` (`date`)
+//  UNIQUE KEY `uk_name_date` (`name`, `date`),
+//  KEY `idx_date` (`date`)
 // ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COMMENT='module download total info';
 
 module.exports = function (sequelize, DataTypes) {
   return sequelize.define('DownloadTotal', {
     name: {
-      type: DataTypes.STRING(100),
+      type: DataTypes.STRING(214),
       allowNull: false,
       comment: 'module name',
     },
@@ -260,10 +260,10 @@ module.exports = function (sequelize, DataTypes) {
     indexes: [
       {
         unique: true,
-        fields: ['name', 'date']
+        fields: ['name', 'date'],
       },
       {
-        fields: ['date']
+        fields: ['date'],
       }
     ],
     classMethods: {

--- a/models/module.js
+++ b/models/module.js
@@ -16,26 +16,24 @@
 
 /*
 CREATE TABLE IF NOT EXISTS `module` (
-  `id` INTEGER NOT NULL auto_increment ,
-  `author` VARCHAR(100) NOT NULL,
-  `name` VARCHAR(100) NOT NULL,
-  `version` VARCHAR(30) NOT NULL,
-  `description` LONGTEXT,
-  `package` LONGTEXT,
-  `dist_shasum` VARCHAR(100),
-  `dist_tarball` VARCHAR(2048),
-  `dist_size` INTEGER UNSIGNED NOT NULL DEFAULT 0,
-  `publish_time` BIGINT(20) UNSIGNED,
-  `gmt_create` DATETIME NOT NULL,
-  `gmt_modified` DATETIME NOT NULL,
-  PRIMARY KEY (`id`)
-)
-COMMENT 'module info' ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE utf8_general_ci;
-
-CREATE UNIQUE INDEX `module_name_version` ON `module` (`name`, `version`);
-CREATE INDEX `module_gmt_modified` ON `module` (`gmt_modified`);
-CREATE INDEX `module_publish_time` ON `module` (`publish_time`);
-CREATE INDEX `module_author` ON `module` (`author`);
+ `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT COMMENT 'primary key',
+ `gmt_create` datetime NOT NULL COMMENT 'create time',
+ `gmt_modified` datetime NOT NULL COMMENT 'modified time',
+ `author` varchar(100) NOT NULL COMMENT 'module author',
+ `name` varchar(214) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL COMMENT 'module name',
+ `version` varchar(30) NOT NULL COMMENT 'module version',
+ `description` longtext COMMENT 'module description',
+ `package` longtext CHARACTER SET utf8 COLLATE utf8_general_ci COMMENT 'package.json',
+ `dist_shasum` varchar(100) DEFAULT NULL COMMENT 'module dist SHASUM',
+ `dist_tarball` varchar(2048) DEFAULT NULL COMMENT 'module dist tarball',
+ `dist_size` int(10) unsigned NOT NULL DEFAULT '0' COMMENT 'module dist size',
+ `publish_time` bigint(20) unsigned COMMENT 'module publish time',
+ PRIMARY KEY (`id`),
+ UNIQUE KEY `uk_name` (`name`,`version`),
+ KEY `idx_gmt_modified` (`gmt_modified`),
+ KEY `idx_publish_time` (`publish_time`),
+ KEY `idx_author` (`author`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COMMENT='module info';
 */
 
 module.exports = function (sequelize, DataTypes) {
@@ -46,7 +44,7 @@ module.exports = function (sequelize, DataTypes) {
       comment: 'first maintainer name'
     },
     name: {
-      type: DataTypes.STRING(100),
+      type: DataTypes.STRING(214),
       allowNull: false,
       comment: 'module name'
     },
@@ -57,6 +55,7 @@ module.exports = function (sequelize, DataTypes) {
     },
     description: {
       type: DataTypes.LONGTEXT,
+      comment: 'module description',
     },
     package: {
       type: DataTypes.LONGTEXT,
@@ -65,19 +64,23 @@ module.exports = function (sequelize, DataTypes) {
     dist_shasum: {
       type: DataTypes.STRING(100),
       allowNull: true,
+      comment: 'module dist SHASUM',
     },
     dist_tarball: {
       type: DataTypes.STRING(2048),
       allowNull: true,
+      comment: 'module dist tarball',
     },
     dist_size: {
       type: DataTypes.INTEGER,
       allowNull: false,
       defaultValue: 0,
+      comment: 'module dist size',
     },
     publish_time: {
       type: DataTypes.BIGINT(20),
       allowNull: true,
+      comment: 'module publish time',
     }
   }, {
     tableName: 'module',
@@ -85,16 +88,16 @@ module.exports = function (sequelize, DataTypes) {
     indexes: [
       {
         unique: true,
-        fields: ['name', 'version']
+        fields: ['name', 'version'],
       },
       {
-        fields: ['gmt_modified']
+        fields: ['gmt_modified'],
       },
       {
-        fields: ['publish_time']
+        fields: ['publish_time'],
       },
       {
-        fields: ['author']
+        fields: ['author'],
       }
     ],
     classMethods: {

--- a/models/module_abbreviated.js
+++ b/models/module_abbreviated.js
@@ -1,9 +1,25 @@
 'use strict';
 
+/*
+CREATE TABLE IF NOT EXISTS `module_abbreviated` (
+ `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT COMMENT 'primary key',
+ `gmt_create` datetime NOT NULL COMMENT 'create time',
+ `gmt_modified` datetime NOT NULL COMMENT 'modified time',
+ `name` varchar(214) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL COMMENT 'module name',
+ `version` varchar(30) NOT NULL COMMENT 'module version',
+ `package` longtext CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci COMMENT 'the abbreviated metadata',
+ `publish_time` bigint(20) unsigned COMMENT 'the publish time',
+ PRIMARY KEY (`id`),
+ UNIQUE KEY `uk_name` (`name`,`version`),
+ KEY `idx_gmt_modified` (`gmt_modified`),
+ KEY `idx_publish_time` (`publish_time`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COMMENT='module abbreviated info';
+ */
+
 module.exports = function (sequelize, DataTypes) {
   return sequelize.define('ModuleAbbreviated', {
     name: {
-      type: DataTypes.STRING(100),
+      type: DataTypes.STRING(214),
       allowNull: false,
       comment: 'module name'
     },
@@ -19,6 +35,7 @@ module.exports = function (sequelize, DataTypes) {
     publish_time: {
       type: DataTypes.BIGINT(20),
       allowNull: true,
+      comment: 'the publish time',
     }
   }, {
     tableName: 'module_abbreviated',
@@ -26,13 +43,13 @@ module.exports = function (sequelize, DataTypes) {
     indexes: [
       {
         unique: true,
-        fields: ['name', 'version']
+        fields: ['name', 'version'],
       },
       {
-        fields: ['gmt_modified']
+        fields: ['gmt_modified'],
       },
       {
-        fields: ['publish_time']
+        fields: ['publish_time'],
       },
     ],
     classMethods: {

--- a/models/module_deps.js
+++ b/models/module_deps.js
@@ -18,18 +18,18 @@
 CREATE TABLE IF NOT EXISTS `module_deps` (
  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT COMMENT 'primary key',
  `gmt_create` datetime NOT NULL COMMENT 'create time',
- `name` varchar(100) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL COMMENT 'module name',
- `deps` varchar(100) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL COMMENT '`name` is deped by `deps`',
+ `name` varchar(214) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL COMMENT 'module name',
+ `deps` varchar(214) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL COMMENT 'which module depend on this module',
  PRIMARY KEY (`id`),
- UNIQUE KEY `module_deps_name_deps` (`name`,`deps`),
- KEY `deps` (`module_deps_deps`)
+ UNIQUE KEY `uk_name_deps` (`name`,`deps`),
+ KEY `idx_name` (`name`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COMMENT='module deps';
  */
 
 module.exports = function (sequelize, DataTypes) {
   return sequelize.define('ModuleDependency', {
     name: {
-      type: DataTypes.STRING(100),
+      type: DataTypes.STRING(214),
       allowNull: false,
       comment: 'module name',
     },
@@ -46,10 +46,10 @@ module.exports = function (sequelize, DataTypes) {
     indexes: [
       {
         unique: true,
-        fields: ['name', 'deps']
+        fields: ['name', 'deps'],
       },
       {
-        fields: ['deps']
+        fields: ['deps'],
       }
     ],
     classMethods: {

--- a/models/module_keyword.js
+++ b/models/module_keyword.js
@@ -19,11 +19,11 @@ CREATE TABLE IF NOT EXISTS `module_keyword` (
  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT COMMENT 'primary key',
  `gmt_create` datetime NOT NULL COMMENT 'create time',
  `keyword` varchar(100) CHARACTER SET utf8 COLLATE utf8_general_ci NOT NULL COMMENT 'keyword',
- `name` varchar(100) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL COMMENT 'module name',
- `description` longtext,
+ `name` varchar(214) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL COMMENT 'module name',
+ `description` longtext COMMENT 'module description',
  PRIMARY KEY (`id`),
- UNIQUE KEY `keyword_module_name` (`keyword`,`name`),
- KEY `name` (`name`)
+ UNIQUE KEY `uk_keyword_module_name` (`keyword`,`name`),
+ KEY `idx_name` (`name`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COMMENT='module keyword';
  */
 
@@ -32,15 +32,17 @@ module.exports = function (sequelize, DataTypes) {
     keyword: {
       type: DataTypes.STRING(100),
       allowNull: false,
+      comment: 'keyword',
     },
     name: {
-      type: DataTypes.STRING(100),
+      type: DataTypes.STRING(214),
       allowNull: false,
       comment: 'module name',
     },
     description: {
       type: DataTypes.LONGTEXT,
       allowNull: true,
+      comment: 'module description',
     }
   }, {
     tableName: 'module_keyword',
@@ -49,10 +51,10 @@ module.exports = function (sequelize, DataTypes) {
     indexes: [
       {
         unique: true,
-        fields: ['keyword', 'name']
+        fields: ['keyword', 'name'],
       },
       {
-        fields: ['name']
+        fields: ['name'],
       }
     ],
     classMethods: {

--- a/models/module_log.js
+++ b/models/module_log.js
@@ -15,15 +15,15 @@
  */
 
 /*
-CREATE TABLE IF NOT EXISTS `module_log` (
+ CREATE TABLE IF NOT EXISTS `module_log` (
  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT COMMENT 'primary key',
  `gmt_create` datetime NOT NULL COMMENT 'create time',
  `gmt_modified` datetime NOT NULL COMMENT 'modified time',
- `username` varchar(100) NOT NULL,
- `name` varchar(100) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL COMMENT 'module name',
- `log` longtext,
+ `username` varchar(100) NOT NULL COMMENT 'which username',
+ `name` varchar(214) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL COMMENT 'module name',
+ `log` longtext COMMENT 'the raw log',
  PRIMARY KEY (`id`),
- KEY `module_log_name` (`name`)
+ KEY `idx_name` (`name`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COMMENT='module sync log';
  */
 
@@ -35,19 +35,20 @@ module.exports = function (sequelize, DataTypes) {
       comment: 'user name'
     },
     name: {
-      type: DataTypes.STRING(100),
+      type: DataTypes.STRING(214),
       allowNull: false,
       comment: 'module name',
     },
     log: {
-      type: DataTypes.LONGTEXT
+      type: DataTypes.LONGTEXT,
+      comment: 'the raw log',
     }
   }, {
     tableName: 'module_log',
     comment: 'module sync log',
     indexes: [
       {
-        fields: ['name']
+        fields: ['name'],
       }
     ],
     classMethods: {

--- a/models/module_maintainer.js
+++ b/models/module_maintainer.js
@@ -19,10 +19,10 @@ CREATE TABLE IF NOT EXISTS `module_maintainer` (
  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT COMMENT 'primary key',
  `gmt_create` datetime NOT NULL COMMENT 'create time',
  `user` varchar(100) CHARACTER SET utf8 COLLATE utf8_general_ci NOT NULL COMMENT 'user name',
- `name` varchar(100) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL COMMENT 'module name',
+ `name` varchar(214) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL COMMENT 'module name',
  PRIMARY KEY (`id`),
- UNIQUE KEY `module_maintainer_user_name` (`user`,`name`),
- KEY `name` (`name`)
+ UNIQUE KEY `uk_user_module_name` (`user`,`name`),
+ KEY `idx_name` (`name`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COMMENT='private module maintainers';
  */
 
@@ -34,7 +34,7 @@ module.exports = function (sequelize, DataTypes) {
       comment: 'user name'
     },
     name: {
-      type: DataTypes.STRING(100),
+      type: DataTypes.STRING(214),
       allowNull: false,
       comment: 'module name',
     }
@@ -45,10 +45,10 @@ module.exports = function (sequelize, DataTypes) {
     indexes: [
       {
         unique: true,
-        fields: ['user', 'name']
+        fields: ['user', 'name'],
       },
       {
-        fields: ['name']
+        fields: ['name'],
       }
     ],
     classMethods: require('./_module_maintainer_class_methods'),

--- a/models/module_star.js
+++ b/models/module_star.js
@@ -19,10 +19,10 @@ CREATE TABLE IF NOT EXISTS `module_star` (
  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT COMMENT 'primary key',
  `gmt_create` datetime NOT NULL COMMENT 'create time',
  `user` varchar(100) CHARACTER SET utf8 COLLATE utf8_general_ci NOT NULL COMMENT 'user name',
- `name` varchar(100) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL COMMENT 'module name',
+ `name` varchar(214) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL COMMENT 'module name',
  PRIMARY KEY (`id`),
- UNIQUE KEY `module_star_user_name` (`user`,`name`),
- KEY `module_star_name` (`name`)
+ UNIQUE KEY `uk_user_module_name` (`user`,`name`),
+ KEY `idx_name` (`name`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COMMENT='module star';
  */
 
@@ -34,7 +34,7 @@ module.exports = function (sequelize, DataTypes) {
       comment: 'user name'
     },
     name: {
-      type: DataTypes.STRING(100),
+      type: DataTypes.STRING(214),
       allowNull: false,
       comment: 'module name',
     }
@@ -45,10 +45,10 @@ module.exports = function (sequelize, DataTypes) {
     indexes: [
       {
         unique: true,
-        fields: ['user', 'name']
+        fields: ['user', 'name'],
       },
       {
-        fields: ['name']
+        fields: ['name'],
       }
     ],
     classMethods: {

--- a/models/module_unpublished.js
+++ b/models/module_unpublished.js
@@ -21,18 +21,18 @@ CREATE TABLE IF NOT EXISTS `module_unpublished` (
  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT COMMENT 'primary key',
  `gmt_create` datetime NOT NULL COMMENT 'create time',
  `gmt_modified` datetime NOT NULL COMMENT 'modified time',
- `name` varchar(100) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL COMMENT 'module name',
+ `name` varchar(214) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL COMMENT 'module name',
  `package` longtext CHARACTER SET utf8 COLLATE utf8_general_ci COMMENT 'base info: tags, time, maintainers, description, versions',
  PRIMARY KEY (`id`),
- UNIQUE KEY `module_unpublished_name` (`name`),
- KEY `module_unpublished_gmt_modified` (`gmt_modified`)
+ UNIQUE KEY `uk_name` (`name`),
+ KEY `idx_gmt_modified` (`gmt_modified`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COMMENT='module unpublished info';
  */
 
 module.exports = function (sequelize, DataTypes) {
   return sequelize.define('ModuleUnpublished', {
     name: {
-      type: DataTypes.STRING(100),
+      type: DataTypes.STRING(214),
       allowNull: false,
       comment: 'module name',
     },
@@ -48,10 +48,10 @@ module.exports = function (sequelize, DataTypes) {
     indexes: [
       {
         unique: true,
-        fields: ['name']
+        fields: ['name'],
       },
       {
-        fields: ['gmt_modified']
+        fields: ['gmt_modified'],
       }
     ],
     classMethods: {

--- a/models/npm_module_maintainer.js
+++ b/models/npm_module_maintainer.js
@@ -19,10 +19,10 @@ CREATE TABLE IF NOT EXISTS `npm_module_maintainer` (
  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT COMMENT 'primary key',
  `gmt_create` datetime NOT NULL COMMENT 'create time',
  `user` varchar(100) CHARACTER SET utf8 COLLATE utf8_general_ci NOT NULL COMMENT 'user name',
- `name` varchar(100) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL COMMENT 'module name',
+ `name` varchar(214) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL COMMENT 'module name',
  PRIMARY KEY (`id`),
- UNIQUE KEY `npm_module_maintainer_user_name` (`user`,`name`),
- KEY `name` (`name`)
+ UNIQUE KEY `uk_user_module_name` (`user`,`name`),
+ KEY `idx_name` (`name`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COMMENT='npm original module maintainers';
  */
 
@@ -34,7 +34,7 @@ module.exports = function (sequelize, DataTypes) {
       comment: 'user name'
     },
     name: {
-      type: DataTypes.STRING(100),
+      type: DataTypes.STRING(214),
       allowNull: false,
       comment: 'module name',
     }
@@ -45,10 +45,10 @@ module.exports = function (sequelize, DataTypes) {
     indexes: [
       {
         unique: true,
-        fields: ['user', 'name']
+        fields: ['user', 'name'],
       },
       {
-        fields: ['name']
+        fields: ['name'],
       }
     ],
     classMethods: require('./_module_maintainer_class_methods'),

--- a/models/package_readme.js
+++ b/models/package_readme.js
@@ -1,9 +1,23 @@
 'use strict';
 
+/*
+CREATE TABLE IF NOT EXISTS `package_readme` (
+ `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT COMMENT 'primary key',
+ `gmt_create` datetime NOT NULL COMMENT 'create time',
+ `gmt_modified` datetime NOT NULL COMMENT 'modified time',
+ `name` varchar(214) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL COMMENT 'module name',
+ `readme` longtext CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci COMMENT 'the latest version readme',
+ `version` varchar(30) NOT NULL COMMENT 'module version',
+ PRIMARY KEY (`id`),
+ UNIQUE KEY `uk_name` (`name`),
+ KEY `idx_gmt_modified` (`gmt_modified`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COMMENT='package latest readme';
+ */
+
 module.exports = function (sequelize, DataTypes) {
   return sequelize.define('PackageReadme', {
     name: {
-      type: DataTypes.STRING(100),
+      type: DataTypes.STRING(214),
       allowNull: false,
       comment: 'module name'
     },
@@ -22,10 +36,10 @@ module.exports = function (sequelize, DataTypes) {
     indexes: [
       {
         unique: true,
-        fields: ['name']
+        fields: ['name'],
       },
       {
-        fields: ['gmt_modified']
+        fields: ['gmt_modified'],
       },
     ],
     classMethods: {

--- a/models/tag.js
+++ b/models/tag.js
@@ -19,20 +19,20 @@ CREATE TABLE IF NOT EXISTS `tag` (
  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT COMMENT 'primary key',
  `gmt_create` datetime NOT NULL COMMENT 'create time',
  `gmt_modified` datetime NOT NULL COMMENT 'modified time',
- `name` varchar(100) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL COMMENT 'module name',
+ `name` varchar(214) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL COMMENT 'module name',
  `tag` varchar(30) NOT NULL COMMENT 'tag name',
  `version` varchar(30) NOT NULL COMMENT 'module version',
  `module_id` bigint(20) unsigned NOT NULL COMMENT 'module id',
  PRIMARY KEY (`id`),
- UNIQUE KEY `tag_name_tag` (`name`, `tag`),
- KEY `tag_gmt_modified` (`gmt_modified`)
+ UNIQUE KEY `uk_name` (`name`, `tag`),
+ KEY `idx_gmt_modified` (`gmt_modified`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COMMENT='module tag';
  */
 
 module.exports = function (sequelize, DataTypes) {
   return sequelize.define('Tag', {
     name: {
-      type: DataTypes.STRING(100),
+      type: DataTypes.STRING(214),
       allowNull: false,
       comment: 'module name',
     },
@@ -57,10 +57,10 @@ module.exports = function (sequelize, DataTypes) {
     indexes: [
       {
         unique: true,
-        fields: ['name', 'tag']
+        fields: ['name', 'tag'],
       },
       {
-        fields: ['gmt_modified']
+        fields: ['gmt_modified'],
       }
     ],
     classMethods: {

--- a/models/total.js
+++ b/models/total.js
@@ -15,7 +15,7 @@
  */
 
 // CREATE TABLE IF NOT EXISTS `total` (
-//  `name` varchar(100) NOT NULL COMMENT 'total name',
+//  `name` varchar(214) NOT NULL COMMENT 'total name',
 //  `gmt_modified` datetime NOT NULL COMMENT 'modified time',
 //  `module_delete` bigint(20) unsigned NOT NULL DEFAULT '0' COMMENT 'module delete count',
 //  `last_sync_time` bigint(20) unsigned NOT NULL DEFAULT '0' COMMENT 'last timestamp sync from official registry',
@@ -35,7 +35,7 @@
 module.exports = function (sequelize, DataTypes) {
   return sequelize.define('Total', {
     name: {
-      type: DataTypes.STRING(100),
+      type: DataTypes.STRING(214),
       primaryKey: true,
       comment: 'total name'
     },

--- a/models/user.js
+++ b/models/user.js
@@ -9,17 +9,17 @@ CREATE TABLE IF NOT EXISTS `user` (
  `gmt_create` datetime NOT NULL COMMENT 'create time',
  `gmt_modified` datetime NOT NULL COMMENT 'modified time',
  `name` varchar(100) NOT NULL COMMENT 'user name',
- `salt` varchar(100) NOT NULL,
+ `salt` varchar(100) NOT NULL COMMENT 'user salt',
  `password_sha` varchar(100) NOT NULL COMMENT 'user password hash',
  `ip` varchar(64) NOT NULL COMMENT 'user last request ip',
- `roles` varchar(200) NOT NULL DEFAULT '[]',
- `rev` varchar(40) NOT NULL,
- `email` varchar(400) NOT NULL,
- `json` longtext CHARACTER SET utf8 COLLATE utf8_general_ci COMMENT 'json details',
+ `roles` varchar(200) NOT NULL DEFAULT '[]' COMMENT 'user roles',
+ `rev` varchar(40) NOT NULL COMMENT 'user rev',
+ `email` varchar(400) NOT NULL COMMENT 'user email',
+ `json` longtext CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci COMMENT 'json details',
  `npm_user` tinyint(1) DEFAULT '0' COMMENT 'user sync from npm or not, 1: true, other: false',
  PRIMARY KEY (`id`),
- UNIQUE KEY `user_name` (`name`),
- KEY `user_gmt_modified` (`gmt_modified`)
+ UNIQUE KEY `uk_name` (`name`),
+ KEY `idx_gmt_modified` (`gmt_modified`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COMMENT='user base info';
 */
 
@@ -33,6 +33,7 @@ module.exports = function (sequelize, DataTypes) {
     salt: {
       type: DataTypes.STRING(100),
       allowNull: false,
+      comment: 'user salt',
     },
     password_sha: {
       type: DataTypes.STRING(100),
@@ -48,14 +49,17 @@ module.exports = function (sequelize, DataTypes) {
       type: DataTypes.STRING(200),
       allowNull: false,
       defaultValue: '[]',
+      comment: 'user roles',
     },
     rev: {
       type: DataTypes.STRING(40),
       allowNull: false,
+      comment: 'user rev',
     },
     email: {
       type: DataTypes.STRING(400),
       allowNull: false,
+      comment: 'user email',
     },
     json: {
       type: DataTypes.LONGTEXT,
@@ -76,10 +80,10 @@ module.exports = function (sequelize, DataTypes) {
     indexes: [
       {
         unique: true,
-        fields: ['name']
+        fields: ['name'],
       },
       {
-        fields: ['gmt_modified']
+        fields: ['gmt_modified'],
       }
     ],
     classMethods: {


### PR DESCRIPTION
Some points:

+ let module name be 214. ([refer](https://docs.npmjs.com/files/package.json#name))
+ indexes (docs/db.sql only):
    - let uniq indexes starts with `uk_`;
    - let other indexes starts with `idx_`;

> Because sqlite's index namespace is the whole database, two tables can't have the same index name. I didn't add the index names to models/*.js.