### PR TITLE
将 npm audit的请求转发到registry.npmjs.org

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,7 @@ coverage/
 config/web_readme.md
 .tmp/
 *.sqlite
+
+.vscode
+
+package-lock.json

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "koa-maxrequests": "^1.0.0",
     "koa-middlewares": "^2.1.0",
     "koa-mock": "^1.6.2",
+    "koa-proxy": "^0.9.0",
     "koa-rewrite": "^1.1.2",
     "koa-rt": "^1.0.0",
     "koa-safe-jsonp": "^0.3.1",

--- a/servers/registry.js
+++ b/servers/registry.js
@@ -20,6 +20,13 @@ var cors = require('kcors');
 var proxyToNpm = require('../middleware/proxy_to_npm');
 var maxrequests = require('koa-maxrequests');
 
+var proxy = require('koa-proxy');
+app.use(proxy({
+  host:  'https://registry.npmjs.org',
+  match: /^\/\-\/npm\/v1\/security\/audits/       
+}));
+
+
 app.use(maxrequests());
 app.use(block());
 middlewares.jsonp(app);


### PR DESCRIPTION

**用koa-proxy把这两个url的请求，转发到https://registry.npmjs.org**
'/-/npm/v1/security/audits'
'/-/npm/v1/security/audits/quick'

**servers/registry.js**
```js

var proxy = require('koa-proxy');
app.use(proxy({
  host:  'https://registry.npmjs.org',
  match: /^\/\-\/npm\/v1\/security\/audits/       
}));
```

参考链接：
https://docs.npmjs.com/auditing-package-dependencies-for-security-vulnerabilities
https://github.com/npm/cli/blob/ab3c62aa83375a7d4a21e396129ae5679ee86646/lib/install/audit.js