### PR TITLE
fix: show package when non-semver version of semver tag

### DIFF
--- a/controllers/web/package/show.js
+++ b/controllers/web/package/show.js
@@ -35,6 +35,14 @@ module.exports = function* show(next) {
   }
 
   var pkg = yield packageService[getPackageMethod].apply(packageService, getPackageArgs);
+  if ((!pkg || !pkg.package) && tag) {
+    // + if we can't find it by tag, it may be a non-semver version, check it then
+    // + if we can't find it by version, it may be a tag, check it then
+    getPackageMethod = version ? 'getModuleByTag' : 'getModule';
+    pkg = yield packageService[getPackageMethod](name, tag);
+  }
+
+  // if it's still not found
   if (!pkg || !pkg.package) {
     // check if unpublished
     var unpublishedInfo = yield packageService.getUnpublishedModule(name);

--- a/routes/web.js
+++ b/routes/web.js
@@ -16,8 +16,8 @@ function routes(app) {
   // scope package without version
   app.get(/\/package\/(@[\w\-\.]+\/[\w\-\.]+)$/, showPackage);
   // scope package with version
-  app.get(/\/package\/(@[\w\-\.]+\/[\w\-\.]+)\/([\w\d\.]+)$/, showPackage);
-  app.get(/\/package\/(@[\w\-\.]+\/[\w\-\.]+)\/v\/([\w\d\.]+)$/, showPackage);
+  app.get(/\/package\/(@[\w\-\.]+\/[\w\-\.]+)\/([\w\-\d\.]+)$/, showPackage);
+  app.get(/\/package\/(@[\w\-\.]+\/[\w\-\.]+)\/v\/([\w\-\d\.]+)$/, showPackage);
   app.get('/package/:name', showPackage);
   app.get('/package/:name/:version', showPackage);
   app.get('/package/:name/v/:version', showPackage);

--- a/test/controllers/web/package/show.test.js
+++ b/test/controllers/web/package/show.test.js
@@ -109,24 +109,38 @@ describe('test/controllers/web/package/show.test.js', () => {
       .expect(/Downloads/, done);
     });
 
-    it('should 200 when get by non-semver version', function (done) {
+    it('should 200 when get by non-semver version', function* () {
       request(app)
       .get('/package/@cnpmtest/testmodule-web-show/0.0.2-alpha')
       .expect(200)
       .expect(/testmodule-web-show/)
       .expect(/Maintainers/)
       .expect(/Dependencies/)
-      .expect(/Downloads/, done);
+      .expect(/Downloads/);
+      request(app)
+      .get('/package/@cnpmtest/testmodule-web-show/v/0.0.2-alpha')
+      .expect(200)
+      .expect(/testmodule-web-show/)
+      .expect(/Maintainers/)
+      .expect(/Dependencies/)
+      .expect(/Downloads/);
     });
 
-    it('should 200 when get by semver tag', function (done) {
+    it('should 200 when get by semver tag', function* () {
       request(app)
       .get('/package/@cnpmtest/testmodule-web-show/1.0.0')
       .expect(200)
       .expect(/testmodule-web-show/)
       .expect(/Maintainers/)
       .expect(/Dependencies/)
-      .expect(/Downloads/, done);
+      .expect(/Downloads/);
+      request(app)
+      .get('/package/@cnpmtest/testmodule-web-show/v/1.0.0')
+      .expect(200)
+      .expect(/testmodule-web-show/)
+      .expect(/Maintainers/)
+      .expect(/Dependencies/)
+      .expect(/Downloads/);
     });
 
     it('should 404 when get by version not exist', function (done) {

--- a/test/controllers/web/package/show.test.js
+++ b/test/controllers/web/package/show.test.js
@@ -9,18 +9,31 @@ var registry = require('../../../../servers/registry');
 var utils = require('../../../utils');
 
 describe('test/controllers/web/package/show.test.js', () => {
-  before(function (done) {
+  before(function* () {
     var pkg = utils.getPackage('@cnpmtest/testmodule-web-show', '0.0.1', utils.admin);
     pkg.versions['0.0.1'].dependencies = {
       bytetest: '~0.0.1',
       mocha: '~1.0.0',
       'testmodule-web-show': '0.0.1'
     };
-    request(registry)
-    .put('/' + pkg.name)
-    .set('authorization', utils.adminAuth)
-    .send(pkg)
-    .expect(201, done);
+    yield request(registry)
+      .put('/' + pkg.name)
+      .set('authorization', utils.adminAuth)
+      .send(pkg)
+      .expect(201);
+    pkg = utils.getPackage('@cnpmtest/testmodule-web-show', '0.0.2-alpha', utils.admin);
+    pkg.versions['0.0.2-alpha'].dependencies = {
+      bytetest: '~0.0.1',
+      mocha: '~1.0.0',
+      'testmodule-web-show': '0.0.1'
+    };
+    pkg['dist-tags'].latest = '0.0.1';
+    pkg['dist-tags']['1.0.0'] = '0.0.2-alpha';
+    yield request(registry)
+      .put('/' + pkg.name)
+      .set('authorization', utils.adminAuth)
+      .send(pkg)
+      .expect(201);
   });
 
   afterEach(mm.restore);
@@ -89,6 +102,26 @@ describe('test/controllers/web/package/show.test.js', () => {
     it('should 200 when get by tag', function (done) {
       request(app)
       .get('/package/@cnpmtest/testmodule-web-show/latest')
+      .expect(200)
+      .expect(/testmodule-web-show/)
+      .expect(/Maintainers/)
+      .expect(/Dependencies/)
+      .expect(/Downloads/, done);
+    });
+
+    it('should 200 when get by non-semver version', function (done) {
+      request(app)
+      .get('/package/@cnpmtest/testmodule-web-show/0.0.2-alpha')
+      .expect(200)
+      .expect(/testmodule-web-show/)
+      .expect(/Maintainers/)
+      .expect(/Dependencies/)
+      .expect(/Downloads/, done);
+    });
+
+    it('should 200 when get by semver tag', function (done) {
+      request(app)
+      .get('/package/@cnpmtest/testmodule-web-show/1.0.0')
       .expect(200)
       .expect(/testmodule-web-show/)
       .expect(/Maintainers/)

--- a/test/controllers/web/show_sync.test.js
+++ b/test/controllers/web/show_sync.test.js
@@ -20,7 +20,7 @@ var app = require('../../../servers/web');
 describe('controllers/web/show_sync.test.js', function () {
   describe('GET /sync/:name', function () {
     it('should display ok', function (done) {
-      request(app.listen())
+      request(app)
       .get('/sync/cutter')
       .expect(200)
       .expect(/Sync package/)


### PR DESCRIPTION
e.g.

https://NPMHOST/package/@scope/name/v/1.7.1-beta-46