### PR TITLE
fix proxy to source when package is public scoped with encoded path

### DIFF
--- a/middleware/proxy_to_npm.js
+++ b/middleware/proxy_to_npm.js
@@ -40,7 +40,7 @@ module.exports = function (options) {
       return yield next;
     }
 
-    var pathname = this.path;
+    var pathname =  decodeURIComponent(this.path);
 
     var isScoped = false;
     var isPublichScoped = false;

--- a/test/middleware/proxy_to_npm.test.js
+++ b/test/middleware/proxy_to_npm.test.js
@@ -48,6 +48,13 @@ describe('test/middleware/proxy_to_npm.test.js', () => {
         .expect('Location', config.sourceNpmRegistry + '/@jkroso/type')
         .expect(302, done);
     });
+
+    it('should proxy to source registry when package is public scoped with encoded path', done => {
+      request(registry)
+        .get('/@jkroso%2Ftype')
+        .expect('Location', config.sourceNpmRegistry + '/@jkroso%2Ftype')
+        .expect(302, done);
+    });
   });
 
   describe('dist-tags', () => {


### PR DESCRIPTION
when use cnpm building private repository, and use yarn or npm to install public scoped package like @types/node, yarn or npm will emit following url with encoded path

https://registry.npm.company.com/@types%2fnode

currently, cnpm won't proxy to source repositry.
this pull request is try to resolve this issue.