### PR TITLE
fix: 同步私包的时候，也需要正确设置publish_on_cnpm参数

### DIFF
--- a/controllers/sync_module_worker.js
+++ b/controllers/sync_module_worker.js
@@ -1460,7 +1460,9 @@ SyncModuleWorker.prototype._syncOneVersion = function *(versionIndex, sourcePack
 
     // delete _publish_on_cnpm, because other cnpm maybe sync from current cnpm
     delete mod.package._publish_on_cnpm;
-    if (that._publish || config.scopes.includes(name)) {
+    var pattern = /((^@[\w|\-]+)\/)?.*/;
+    var scope = sourcePackage.name.match(pattern)[2];
+    if (that._publish || config.scopes.includes(scope)) {
       // sync as publish
       mod.package._publish_on_cnpm = true;
     }

--- a/controllers/sync_module_worker.js
+++ b/controllers/sync_module_worker.js
@@ -1460,7 +1460,7 @@ SyncModuleWorker.prototype._syncOneVersion = function *(versionIndex, sourcePack
 
     // delete _publish_on_cnpm, because other cnpm maybe sync from current cnpm
     delete mod.package._publish_on_cnpm;
-    if (that._publish) {
+    if (that._publish || config.scopes.includes(name)) {
       // sync as publish
       mod.package._publish_on_cnpm = true;
     }


### PR DESCRIPTION
如果当前服务器的上游是公司的老的私服，同步私包时，需要同时设置好这个字段，防止迁移用户后，原来的maintainer无法发包