### PR TITLE
fix: 修复主从延迟导致的潜在tag指针指向问题

### DIFF
--- a/controllers/registry/package/save.js
+++ b/controllers/registry/package/save.js
@@ -189,11 +189,11 @@ module.exports = function* save(next) {
   };
 
   mod.package.dist = dist;
-  yield addDepsRelations(mod.package);
-
   var addResult = yield packageService.saveModule(mod);
   debug('%s module: save file to %s, size: %d, sha1: %s, dist: %j, version: %s',
     addResult.id, dist.tarball, dist.size, shasum, dist, version);
+  
+  yield addDepsRelations(mod.package);
 
   if (tags.length) {
     yield tags.map(function (tag) {


### PR DESCRIPTION
这里在module表插入数据，马上在addTag的时候读取module表里面的数据，如果做了读写分离，因为主从延迟addTag的时候有失败的风险