### PR TITLE
rename `reason` property to `error` when error response

### DIFF
--- a/controllers/registry/package/deprecate.js
+++ b/controllers/registry/package/deprecate.js
@@ -23,9 +23,10 @@ function* deprecateVersions() {
     if (!row) {
       // some version not exists
       this.status = 400;
+      const error = '[version_error] Some versions: ' + JSON.stringify(Object.keys(body.versions)) + ' not found';
       this.body = {
-        error: 'version_error',
-        reason: 'Some versions: ' + JSON.stringify(Object.keys(body.versions)) + ' not found'
+        error,
+        reason: error,
       };
       return;
     }

--- a/controllers/registry/package/dist_tag.js
+++ b/controllers/registry/package/dist_tag.js
@@ -49,9 +49,10 @@ exports.set = function* () {
   var pkg = yield packageService.getModule(name, version);
   if (!pkg) {
     this.status = 400;
+    const error = '[version_error] ' + name + '@' + version + ' not exists';
     this.body = {
-      error: 'version_error',
-      reason: name + '@' + version + ' not exists'
+      error,
+      reason: error,
     };
     return;
   }
@@ -67,9 +68,10 @@ exports.destroy = function* () {
   var tag = this.params.tag || this.params[1];
   if (tag === 'latest') {
     this.status = 400;
+    const error = '[dist_tag_error] Can\'t not delete latest tag';
     this.body = {
-      error: 'dist_tag_error',
-      reason: 'Can\'t not delete latest tag',
+      error,
+      reason: error,
     };
     return;
   }

--- a/controllers/registry/package/download_total.js
+++ b/controllers/registry/package/download_total.js
@@ -12,9 +12,10 @@ module.exports = function* downloadTotal() {
       || !range[0].match(DATE_REG)
       || !range[1].match(DATE_REG)) {
     this.status = 400;
+    const error = '[range_error] range must be YYYY-MM-DD:YYYY-MM-DD style';
     this.body = {
-      error: 'range_error',
-      reason: 'range must be YYYY-MM-DD:YYYY-MM-DD style'
+      error,
+      reason: error,
     };
     return;
   }

--- a/controllers/registry/package/list.js
+++ b/controllers/registry/package/list.js
@@ -140,9 +140,10 @@ module.exports = function* list() {
   if (rows.length === 0) {
     if (!this.allowSync) {
       this.status = 404;
+      const error = '[not_found] document not found';
       this.jsonp = {
-        error: 'not_found',
-        reason: 'document not found',
+        error,
+        reason: error,
       };
       return;
     }

--- a/controllers/registry/package/list_since.js
+++ b/controllers/registry/package/list_since.js
@@ -12,9 +12,10 @@ module.exports = function* listSince() {
   var query = this.query;
   if (query.stale !== 'update_after') {
     this.status = 400;
+    const error = '[query_parse_error] Invalid value for `stale`.';
     this.body = {
-      error: 'query_parse_error',
-      reason: 'Invalid value for `stale`.'
+      error,
+      reason: error,
     };
     return;
   }
@@ -22,9 +23,10 @@ module.exports = function* listSince() {
   var startkey = Number(query.startkey);
   if (!startkey) {
     this.status = 400;
+    const error = '[query_parse_error] Invalid value for `startkey`.';
     this.body = {
-      error: 'query_parse_error',
-      reason: 'Invalid value for `startkey`.'
+      error,
+      reason: error,
     };
     return;
   }

--- a/controllers/registry/package/save.js
+++ b/controllers/registry/package/save.js
@@ -31,9 +31,10 @@ module.exports = function* save(next) {
   var version = Object.keys(pkg.versions || {})[0];
   if (!version) {
     this.status = 400;
+    const error = '[version_error] package.versions is empty';
     this.body = {
-      error: 'version_error',
-      reason: 'package.versions is empty'
+      error,
+      reason: error,
     };
     return;
   }
@@ -42,10 +43,11 @@ module.exports = function* save(next) {
   var result = yield packageService.authMaintainer(name, username);
   if (!result.isMaintainer) {
     this.status = 403;
+    const error = '[forbidden] ' +  username + ' not authorized to modify ' + name +
+      ', please contact maintainers: ' + result.maintainers.join(', ');
     this.body = {
-      error: 'forbidden user',
-      reason: username + ' not authorized to modify ' + name +
-        ', please contact maintainers: ' + result.maintainers.join(', ')
+      error,
+      reason: error,
     };
     return;
   }
@@ -64,9 +66,10 @@ module.exports = function* save(next) {
     }
 
     this.status = 400;
+    const error = '[attachment_error] package._attachments is empty';
     this.body = {
-      error: 'attachment_error',
-      reason: 'package._attachments is empty'
+      error,
+      reason: error,
     };
     return;
   }
@@ -78,9 +81,10 @@ module.exports = function* save(next) {
   // should never happened in normal request
   if (!maintainers) {
     this.status = 400;
+    const error = '[maintainers_error] request body need maintainers';
     this.body = {
-      error: 'maintainers error',
-      reason: 'request body need maintainers'
+      error,
+      reason: error,
     };
     return;
   }
@@ -95,9 +99,10 @@ module.exports = function* save(next) {
   });
   if (m.length === 0) {
     this.status = 403;
+    const error = '[maintainers_error] ' + username + ' does not in maintainer list';
     this.body = {
-      error: 'maintainers error',
-      reason: username + ' does not in maintainer list'
+      error,
+      reason: error,
     };
     return;
   }
@@ -112,9 +117,10 @@ module.exports = function* save(next) {
 
   if (tags.length === 0) {
     this.status = 400;
+    const error = '[invalid] dist-tags should not be empty';
     this.body = {
-      error: 'invalid',
-      reason: 'dist-tags should not be empty'
+      error,
+      reason: error,
     };
     return;
   }
@@ -126,9 +132,10 @@ module.exports = function* save(next) {
   var shasum;
   if (exists) {
     this.status = 403;
+    const error = '[forbidden] cannot modify pre-existing version: ' + version;
     this.body = {
-      error: 'forbidden',
-      reason: 'cannot modify pre-existing version: ' + version
+      error,
+      reason: error,
     };
     return;
   }
@@ -139,10 +146,11 @@ module.exports = function* save(next) {
 
   if (tarballBuffer.length !== attachment.length) {
     this.status = 403;
+    const error = '[size_wrong] Attachment size ' + attachment.length
+      + ' not match download size ' + tarballBuffer.length;
     this.body = {
-      error: 'size_wrong',
-      reason: 'Attachment size ' + attachment.length
-        + ' not match download size ' + tarballBuffer.length,
+      error,
+      reason: error,
     };
     return;
   }

--- a/controllers/registry/package/show.js
+++ b/controllers/registry/package/show.js
@@ -59,9 +59,10 @@ module.exports = function* show() {
   // if not fond, sync from source registry
   if (!this.allowSync) {
     this.status = 404;
+    const error = '[not_exists] version not found: ' + version;
     this.jsonp = {
-      error: 'not exist',
-      reason: 'version not found: ' + version
+      error,
+      reason: error,
     };
     return;
   }

--- a/controllers/registry/package/tag.js
+++ b/controllers/registry/package/tag.js
@@ -16,20 +16,21 @@ module.exports = function* tag() {
 
   if (!version) {
     this.status = 400;
+    const error = '[version_missed] version not found';
     this.body = {
-      error: 'version_missed',
-      reason: 'version not found'
+      error,
+      reason: error,
     };
     return;
   }
 
   if (!semver.valid(version)) {
     this.status = 403;
-    var reason = util.format('setting tag %s to invalid version: %s: %s/%s',
+    const error = util.format('[forbidden] setting tag %s to invalid version: %s: %s/%s',
       tag, version, name, tag);
     this.body = {
-      error: 'forbidden',
-      reason: reason
+      error,
+      reason: error,
     };
     return;
   }
@@ -37,11 +38,11 @@ module.exports = function* tag() {
   var mod = yield packageService.getModule(name, version);
   if (!mod) {
     this.status = 403;
-    var reason = util.format('setting tag %s to unknown version: %s: %s/%s',
+    const error = util.format('[forbidden] setting tag %s to unknown version: %s: %s/%s',
       tag, version, name, tag);
     this.body = {
-      error: 'forbidden',
-      reason: reason
+      error,
+      reason: error,
     };
     return;
   }
@@ -50,6 +51,6 @@ module.exports = function* tag() {
   this.status = 201;
   this.body = {
     ok: true,
-    modified: row.gmt_modified
+    modified: row.gmt_modified,
   };
 };

--- a/controllers/registry/package/update.js
+++ b/controllers/registry/package/update.js
@@ -108,9 +108,10 @@ function* updateMaintainers() {
 
   if (usernames.length === 0) {
     this.status = 403;
+    const error = '[invalid_operation] Can not remove all maintainers';
     this.body = {
-      error: 'invalid operation',
-      reason: 'Can not remove all maintainers'
+      error,
+      reason: error,
     };
     return;
   }
@@ -145,9 +146,10 @@ function* updateMaintainers() {
       }
       if (invailds.length > 0) {
         this.status = 403;
+        const error = '[invalid] User: `' + invailds.join(', ') + '` not exists';
         this.body = {
-          error: 'invalid user name',
-          reason: 'User: `' + invailds.join(', ') + '` not exists'
+          error,
+          reason: error,
         };
         return;
       }

--- a/controllers/registry/user/add.js
+++ b/controllers/registry/user/add.js
@@ -43,9 +43,10 @@ module.exports = function* addUser() {
 
   if (!body.password || !body.name) {
     this.status = 422;
+    const error = '[param_error] params missing, name, email or password missing';
     this.body = {
-      error: 'paramError',
-      reason: 'params missing, name, email or password missing.'
+      error,
+      reason: error,
     };
     return;
   }
@@ -56,8 +57,8 @@ module.exports = function* addUser() {
   } catch (err) {
     this.status = err.status || 500;
     this.body = {
-      error: err.name,
-      reason: err.message
+      error: err.message,
+      reason: err.message,
     };
     return;
   }
@@ -74,9 +75,10 @@ module.exports = function* addUser() {
   if (config.customUserService) {
     // user login fail, not allow to add new user
     this.status = 401;
+    const error = '[unauthorized] Login fail, please check your login name and password';
     this.body = {
-      error: 'unauthorized',
-      reason: 'Login fail, please check your login name and password'
+      error,
+      reason: error,
     };
     return;
   }
@@ -94,9 +96,10 @@ module.exports = function* addUser() {
 
   if (!user.salt || !user.password_sha || !user.email) {
     this.status = 422;
+    const error = '[param_error] params missing, name, email or password missing';
     this.body = {
-      error: 'paramError',
-      reason: 'params missing, name, email or password missing.'
+      error,
+      reason: error,
     };
     return;
   }
@@ -104,9 +107,10 @@ module.exports = function* addUser() {
   var existUser = yield userService.get(name);
   if (existUser) {
     this.status = 409;
+    const error = '[conflict] User ' + name + ' already exists';
     this.body = {
-      error: 'conflict',
-      reason: 'User ' + name + ' already exists.'
+      error,
+      reason: error,
     };
     return;
   }

--- a/controllers/registry/user/update.js
+++ b/controllers/registry/user/update.js
@@ -32,9 +32,10 @@ module.exports = function* updateUser(next) {
   if (name !== this.user.name) {
     // must auth user first
     this.status = 401;
+    const error = '[unauthorized] Name is incorrect';
     this.body = {
-      error: 'unauthorized',
-      reason: 'Name is incorrect.'
+      error,
+      reason: error,
     };
     return;
   }
@@ -56,9 +57,10 @@ module.exports = function* updateUser(next) {
 
   if (!body.password || !user.name || !user.salt || !user.password_sha || !user.email) {
     this.status = 422;
+    const error = '[param_error] params missing, name, email or password missing';
     this.body = {
-      error: 'paramError',
-      reason: 'params missing, name, email or password missing.'
+      error,
+      reason: error,
     };
     return;
   }
@@ -66,9 +68,10 @@ module.exports = function* updateUser(next) {
   var result = yield userService.update(user);
   if (!result) {
     this.status = 409;
+    const error = '[conflict] Document update conflict';
     this.body = {
-      error: 'conflict',
-      reason: 'Document update conflict.'
+      error,
+      reason: error,
     };
     return;
   }

--- a/controllers/registry/user_package.js
+++ b/controllers/registry/user_package.js
@@ -21,9 +21,10 @@ exports.list = function* () {
   var users = this.params.user.split('|');
   if (users.length > 20) {
     this.status = 400;
+    const error = '[bad_request] reach max user names limit, must <= 20 user names';
     this.body = {
-      error: 'bad_request',
-      reason: 'reach max user names limit, must <= 20 user names'
+      error,
+      reason: error,
     };
     return;
   }

--- a/controllers/sync.js
+++ b/controllers/sync.js
@@ -25,9 +25,10 @@ exports.sync = function* () {
   debug('sync %s with query: %j, syncUpstreamFirst: %s', name, this.query, syncUpstreamFirst);
   if (type === 'package' && publish && !this.user.isAdmin) {
     this.status = 403;
+    const error = '[no_perms] Only admin can publish';
     this.body = {
-      error: 'no_perms',
-      reason: 'Only admin can publish'
+      error,
+      reason: error,
     };
     return;
   }

--- a/middleware/auth.js
+++ b/middleware/auth.js
@@ -58,9 +58,10 @@ function* unauthorized(next) {
   this.status = 401;
   this.set('WWW-Authenticate', 'Basic realm="sample"');
   if (this.accepts(['html', 'json']) === 'json') {
+    const error = '[unauthorized] login first';
     this.body = {
-      error: 'unauthorized',
-      reason: 'login first'
+      error,
+      reason: error,
     };
   } else {
     this.body = 'login first';

--- a/middleware/editable.js
+++ b/middleware/editable.js
@@ -21,8 +21,9 @@ module.exports = function* editable(next) {
   if (username) {
     message = username + ' ' + message;
   }
+  message = '[forbidden] ' + message;
   this.body = {
-    error: 'forbidden user',
-    reason: message
+    error: message,
+    reason: message,
   };
 };

--- a/middleware/exists_package.js
+++ b/middleware/exists_package.js
@@ -9,8 +9,9 @@ module.exports = function* (next) {
     return yield next;
   }
   this.status = 404;
+  const error = '[not_found] document not found';
   this.body = {
-    error: 'not_found',
-    reason: 'document not found'
+    error,
+    reason: error,
   };
 };

--- a/middleware/login.js
+++ b/middleware/login.js
@@ -9,18 +9,20 @@ module.exports = function *login(next) {
       ? status
       : 500;
 
+    const error = `[${this.user.error.name}] ${this.user.error.message}`;
     this.body = {
-      error: this.user.error.name,
-      reason: this.user.error.message
+      error,
+      reason: error,
     };
     return;
   }
 
   if (!this.user.name) {
     this.status = 401;
+    const error = '[unauthorized] Login first';
     this.body = {
-      error: 'unauthorized',
-      reason: 'Login first'
+      error,
+      reason: error,
     };
     return;
   }

--- a/middleware/publishable.js
+++ b/middleware/publishable.js
@@ -1,18 +1,4 @@
-/**!
- * cnpmjs.org - middleware/publishable.js
- *
- * Copyright(c) cnpmjs.org and other contributors.
- * MIT Licensed
- *
- * Authors:
- *  fengmk2 <fengmk2@gmail.com> (http://fengmk2.github.com)
- */
-
 'use strict';
-
-/**
- * Module dependencies.
- */
 
 var util = require('util');
 var config = require('../config');
@@ -27,9 +13,10 @@ module.exports = function *publishable(next) {
   // private mode, normal user can't publish and unpublish
   if (config.enablePrivate) {
     this.status = 403;
+    const error = '[no_perms] Private mode enable, only admin can publish this module';
     this.body = {
-      error: 'no_perms',
-      reason: 'Private mode enable, only admin can publish this module'
+      error,
+      reason: error,
     };
     return;
   }
@@ -70,9 +57,10 @@ function checkScope(name, ctx) {
   if (ctx.user.scopes.indexOf(scope) === -1) {
     debug('assert scope  %s error', name);
     ctx.status = 400;
+    const error = util.format('[invalid] scope %s not match legal scopes: %s', scope, ctx.user.scopes.join(', '));
     ctx.body = {
-      error: 'invalid scope',
-      reason: util.format('scope %s not match legal scopes: %s', scope, ctx.user.scopes.join(', '))
+      error,
+      reason: error,
     };
     return false;
   }
@@ -87,15 +75,17 @@ function checkScope(name, ctx) {
 function assertNoneScope(name, ctx) {
   ctx.status = 403;
   if (ctx.user.scopes.length === 0) {
+    const error = '[no_perms] can\'t publish non-scoped package, please set `config.scopes`';
     ctx.body = {
-      error: 'no_perms',
-      reason: 'can\'t publish non-scoped package, please set `config.scopes`'
+      error,
+      reason: error,
     };
     return;
   }
 
+  const error = '[no_perms] only allow publish with ' + ctx.user.scopes.join(', ') + ' scope(s)';
   ctx.body = {
-    error: 'no_perms',
-    reason: 'only allow publish with ' + ctx.user.scopes.join(', ') + ' scope(s)'
+    error,
+    reason: error,
   };
 }

--- a/middleware/registry_not_found.js
+++ b/middleware/registry_not_found.js
@@ -11,8 +11,9 @@ module.exports = function* notFound(next) {
   }
 
   this.status = 404;
+  const error = '[not_found] document not found';
   this.body = {
-    error: 'not_found',
-    reason: 'document not found'
+    error,
+    reason: error,
   };
 };

--- a/middleware/unpublishable.js
+++ b/middleware/unpublishable.js
@@ -1,22 +1,13 @@
-/**!
- * cnpmjs.org - middleware/unpublishable.js
- *
- * Copyright(c) cnpmjs.org and other contributors.
- * MIT Licensed
- *
- * Authors:
- *  dead_horse <dead_horse@qq.com>
- */
-
 'use strict';
 
 module.exports = function *unpublishable(next) {
   // only admin user can unpublish
   if (!this.user.isAdmin) {
     this.status = 403;
+    const error = '[no_perms] Only administrators can unpublish module';
     this.body = {
-      error: 'no_perms',
-      reason: 'Only administrators can unpublish module',
+      error,
+      reason: error,
     };
     return;
   }

--- a/test/controllers/registry/module/config_private_packages.test.js
+++ b/test/controllers/registry/module/config_private_packages.test.js
@@ -44,8 +44,8 @@ describe('controllers/registry/module/config_private_packages.test.js', function
       .expect(403, function (err, res) {
         should.not.exist(err);
         res.body.should.eql({
-          error: 'forbidden',
-          reason: 'cannot modify pre-existing version: 0.0.1'
+          error: '[forbidden] cannot modify pre-existing version: 0.0.1',
+          reason: '[forbidden] cannot modify pre-existing version: 0.0.1',
         });
         done();
       });
@@ -58,7 +58,7 @@ describe('controllers/registry/module/config_private_packages.test.js', function
     .put('/' + pkg.name)
     .set('authorization', utils.secondUserAuth)
     .send(pkg)
-    .expect(/forbidden user/)
+    .expect(/not authorized to modify private-package/)
     .expect(403, done);
   });
 
@@ -68,7 +68,7 @@ describe('controllers/registry/module/config_private_packages.test.js', function
     .put('/' + pkg.name)
     .set('authorization', utils.adminAuth)
     .send(pkg)
-    .expect(/forbidden user/)
+    .expect(/not authorized to modify private-package/)
     .expect(403, done);
   });
 

--- a/test/controllers/registry/module/maintainer.test.js
+++ b/test/controllers/registry/module/maintainer.test.js
@@ -54,8 +54,8 @@ describe('test/controllers/registry/module/maintainer.test.js', function () {
         ]
       })
       .expect({
-        error: 'invalid user name',
-        reason: 'User: `new-maintainer-not-exists, new-maintainer-not-exists2` not exists'
+        error: '[invalid] User: `new-maintainer-not-exists, new-maintainer-not-exists2` not exists',
+        reason: '[invalid] User: `new-maintainer-not-exists, new-maintainer-not-exists2` not exists',
       })
       .expect(403, done);
     });

--- a/test/controllers/registry/package/deprecate.test.js
+++ b/test/controllers/registry/package/deprecate.test.js
@@ -165,8 +165,8 @@ describe('test/controllers/registry/package/deprecate.test.js', function () {
         }
       })
       .expect({
-        error: 'version_error',
-        reason: 'Some versions: ["1.0.1","1.0.0"] not found'
+        error: '[version_error] Some versions: ["1.0.1","1.0.0"] not found',
+        reason: '[version_error] Some versions: ["1.0.1","1.0.0"] not found',
       })
       .expect(400, done);
     });
@@ -190,8 +190,8 @@ describe('test/controllers/registry/package/deprecate.test.js', function () {
         }
       })
       .expect({
-        error: 'forbidden user',
-        reason: 'cnpmjstest101 not authorized to modify @cnpmtest/testmodule-deprecate, please contact maintainers: cnpmjstest10'
+        error: '[forbidden] cnpmjstest101 not authorized to modify @cnpmtest/testmodule-deprecate, please contact maintainers: cnpmjstest10',
+        reason: '[forbidden] cnpmjstest101 not authorized to modify @cnpmtest/testmodule-deprecate, please contact maintainers: cnpmjstest10',
       })
       .expect(403, done);
     });

--- a/test/controllers/registry/package/dist_tag.test.js
+++ b/test/controllers/registry/package/dist_tag.test.js
@@ -58,8 +58,8 @@ describe('test/controllers/registry/package/dist_tag.test.js', function () {
       .get('/-/package/@cnpmtest/not-exists/dist-tags')
       .expect(404)
       .expect({
-        error: 'not_found',
-        reason: 'document not found'
+        error: '[not_found] document not found',
+        reason: '[not_found] document not found',
       }, done);
     });
   });
@@ -89,8 +89,8 @@ describe('test/controllers/registry/package/dist_tag.test.js', function () {
       .set('content-type', 'application/json')
       .send(JSON.stringify('2.0.1'))
       .expect({
-        error: 'version_error',
-        reason: '@cnpmtest/dist_tag_test_module_set@2.0.1 not exists'
+        error: '[version_error] @cnpmtest/dist_tag_test_module_set@2.0.1 not exists',
+        reason: '[version_error] @cnpmtest/dist_tag_test_module_set@2.0.1 not exists',
       })
       .expect(400, done);
     });
@@ -162,8 +162,8 @@ describe('test/controllers/registry/package/dist_tag.test.js', function () {
       .set('authorization', utils.otherUserAuth)
       .set('content-type', 'application/json')
       .expect({
-        error: 'dist_tag_error',
-        reason: 'Can\'t not delete latest tag',
+        error: '[dist_tag_error] Can\'t not delete latest tag',
+        reason: '[dist_tag_error] Can\'t not delete latest tag',
       })
       .expect(400, done);
     });

--- a/test/controllers/registry/package/download_total.test.js
+++ b/test/controllers/registry/package/download_total.test.js
@@ -23,8 +23,8 @@ describe('test/controllers/registry/package/download_total.test.js', () => {
     .get('/downloads/range/2014-10-10:xxxx/koa')
     .expect(400)
     .expect({
-      error: 'range_error',
-      reason: 'range must be YYYY-MM-DD:YYYY-MM-DD style'
+      error: '[range_error] range must be YYYY-MM-DD:YYYY-MM-DD style',
+      reason: '[range_error] range must be YYYY-MM-DD:YYYY-MM-DD style',
     });
   });
 

--- a/test/controllers/registry/package/list.test.js
+++ b/test/controllers/registry/package/list.test.js
@@ -149,8 +149,8 @@ describe('test/controllers/registry/package/list.test.js', () => {
     .get('/@cnpmtest/not-exists-package')
     .expect(404)
     .expect({
-      error: 'not_found',
-      reason: 'document not found'
+      error: '[not_found] document not found',
+      reason: '[not_found] document not found',
     }, done);
   });
 
@@ -160,8 +160,8 @@ describe('test/controllers/registry/package/list.test.js', () => {
     .get('/@cnpmtest/not-exists-package')
     .expect(404)
     .expect({
-      error: 'not_found',
-      reason: 'document not found'
+      error: '[not_found] document not found',
+      reason: '[not_found] document not found',
     }, done);
   });
 
@@ -178,8 +178,8 @@ describe('test/controllers/registry/package/list.test.js', () => {
     .get('/@cnpmtest/pedding')
     .expect(404)
     .expect({
-      error: 'not_found',
-      reason: 'document not found'
+      error: '[not_found] document not found',
+      reason: '[not_found] document not found',
     }, done);
   });
 
@@ -289,8 +289,8 @@ describe('test/controllers/registry/package/list.test.js', () => {
         .set('Accept', 'application/vnd.npm.install-v1+json')
         .expect(404)
         .expect({
-          error: 'not_found',
-          reason: 'document not found'
+          error: '[not_found] document not found',
+          reason: '[not_found] document not found',
         });
     });
 

--- a/test/controllers/registry/package/list_since.test.js
+++ b/test/controllers/registry/package/list_since.test.js
@@ -49,8 +49,8 @@ describe('test/controllers/registry/package/list_since.test.js', function () {
       request(app)
       .get('/-/all/since')
       .expect({
-        error: 'query_parse_error',
-        reason: 'Invalid value for `stale`.'
+        error: '[query_parse_error] Invalid value for `stale`.',
+        reason: '[query_parse_error] Invalid value for `stale`.',
       })
       .expect(400, done);
     });
@@ -59,8 +59,8 @@ describe('test/controllers/registry/package/list_since.test.js', function () {
       request(app)
       .get('/-/all/since?stale=update_after&startkey=')
       .expect({
-        error: 'query_parse_error',
-        reason: 'Invalid value for `startkey`.'
+        error: '[query_parse_error] Invalid value for `startkey`.',
+        reason: '[query_parse_error] Invalid value for `startkey`.',
       })
       .expect(400, done);
     });
@@ -69,8 +69,8 @@ describe('test/controllers/registry/package/list_since.test.js', function () {
       request(app)
       .get('/-/all/since?stale=update_after&startkey=foo')
       .expect({
-        error: 'query_parse_error',
-        reason: 'Invalid value for `startkey`.'
+        error: '[query_parse_error] Invalid value for `startkey`.',
+        reason: '[query_parse_error] Invalid value for `startkey`.',
       })
       .expect(400, done);
     });

--- a/test/controllers/registry/package/remove.test.js
+++ b/test/controllers/registry/package/remove.test.js
@@ -25,8 +25,8 @@ describe('test/controllers/registry/package/remove.test.js', function () {
     request(app)
     .del('/@cnpmtest/testmodule-remove-1/-rev/1')
     .expect({
-      error: 'unauthorized',
-      reason: 'Login first'
+      error: '[unauthorized] Login first',
+      reason: '[unauthorized] Login first',
     })
     .expect(401, done);
   });
@@ -36,8 +36,8 @@ describe('test/controllers/registry/package/remove.test.js', function () {
     .del('/@cnpmtest/testmodule-remove-1-not-exists/-rev/1')
     .set('authorization', utils.adminAuth)
     .expect({
-      error: 'not_found',
-      reason: 'document not found'
+      error: '[not_found] document not found',
+      reason: '[not_found] document not found',
     })
     .expect(404, done);
   });
@@ -47,8 +47,8 @@ describe('test/controllers/registry/package/remove.test.js', function () {
     .del('/@cnpmtest/testmodule-remove-1/-rev/1')
     .set('authorization', utils.otherUserAuth)
     .expect({
-      error: 'no_perms',
-      reason: 'Only administrators can unpublish module'
+      error: '[no_perms] Only administrators can unpublish module',
+      reason: '[no_perms] Only administrators can unpublish module',
     })
     .expect(403, done);
   });

--- a/test/controllers/registry/package/remove_version.test.js
+++ b/test/controllers/registry/package/remove_version.test.js
@@ -30,8 +30,8 @@ describe('test/controllers/registry/package/remove_version.test.js', function ()
     .del('/@cnpmtest/testmodule-remove_version-1/download/@cnpmtest/testmodule_remove_version123.tgz/-rev/112312312321')
     .set('authorization', utils.adminAuth)
     .expect({
-      error: 'not_found',
-      reason: 'document not found'
+      error: '[not_found] document not found',
+      reason: '[not_found] document not found',
     })
     .expect(404, done);
   });
@@ -41,8 +41,8 @@ describe('test/controllers/registry/package/remove_version.test.js', function ()
     .del('/@cnpmtest/testmodule-remove_version-1/download/@cnpmtest/testmodule-remove_version-1-1.0.1.tgz/-rev/abc')
     .set('authorization', utils.adminAuth)
     .expect({
-      error: 'not_found',
-      reason: 'document not found'
+      error: '[not_found] document not found',
+      reason: '[not_found] document not found',
     })
     .expect(404, done);
   });
@@ -52,8 +52,8 @@ describe('test/controllers/registry/package/remove_version.test.js', function ()
     .del('/@cnpmtest/testmodule-remove_version-1/download/@cnpmtest/testmodule-remove_version-1-1.0.1.tgz/-rev/112312312321')
     .set('authorization', utils.adminAuth)
     .expect({
-      error: 'not_found',
-      reason: 'document not found'
+      error: '[not_found] document not found',
+      reason: '[not_found] document not found',
     })
     .expect(404, done);
   });

--- a/test/controllers/registry/package/save.test.js
+++ b/test/controllers/registry/package/save.test.js
@@ -152,8 +152,8 @@ describe('test/controllers/registry/package/save.test.js', function () {
       .set('authorization', utils.adminAuth)
       .send(pkg)
       .expect({
-        error: 'version_error',
-        reason: 'package.versions is empty'
+        error: '[version_error] package.versions is empty',
+        reason: '[version_error] package.versions is empty',
       })
       .expect(400, done);
     });
@@ -166,8 +166,8 @@ describe('test/controllers/registry/package/save.test.js', function () {
       .set('authorization', utils.adminAuth)
       .send(pkg)
       .expect({
-        error: 'maintainers error',
-        reason: 'request body need maintainers'
+        error: '[maintainers_error] request body need maintainers',
+        reason: '[maintainers_error] request body need maintainers',
       })
       .expect(400, done);
     });
@@ -180,8 +180,8 @@ describe('test/controllers/registry/package/save.test.js', function () {
       .set('authorization', utils.adminAuth)
       .send(pkg)
       .expect({
-        error: 'invalid',
-        reason: 'dist-tags should not be empty'
+        error: '[invalid] dist-tags should not be empty',
+        reason: '[invalid] dist-tags should not be empty',
       })
       .expect(400, done);
     });
@@ -194,8 +194,8 @@ describe('test/controllers/registry/package/save.test.js', function () {
       .set('authorization', utils.adminAuth)
       .send(pkg)
       .expect({
-        error: 'maintainers error',
-        reason: utils.admin + ' does not in maintainer list'
+        error: '[maintainers_error] ' + utils.admin + ' does not in maintainer list',
+        reason: '[maintainers_error] ' + utils.admin + ' does not in maintainer list'
       })
       .expect(403, done);
     });
@@ -208,8 +208,8 @@ describe('test/controllers/registry/package/save.test.js', function () {
       .set('authorization', utils.adminAuth)
       .send(pkg)
       .expect({
-        error: 'attachment_error',
-        reason: 'package._attachments is empty'
+        error: '[attachment_error] package._attachments is empty',
+        reason: '[attachment_error] package._attachments is empty',
       })
       .expect(400, done);
     });
@@ -222,8 +222,8 @@ describe('test/controllers/registry/package/save.test.js', function () {
       .set('authorization', utils.adminAuth)
       .send(pkg)
       .expect({
-        error: 'size_wrong',
-        reason: 'Attachment size 261 not match download size 251'
+        error: '[size_wrong] Attachment size 261 not match download size 251',
+        reason: '[size_wrong] Attachment size 261 not match download size 251',
       })
       .expect(403, done);
     });
@@ -235,8 +235,8 @@ describe('test/controllers/registry/package/save.test.js', function () {
       .set('authorization', utils.otherAdmin2Auth)
       .send(pkg)
       .expect({
-        error: 'forbidden user',
-        reason: 'cnpmjstestAdmin2 not authorized to modify testmodule-new-1, please contact maintainers: cnpmjstest10'
+        error: '[forbidden] cnpmjstestAdmin2 not authorized to modify testmodule-new-1, please contact maintainers: cnpmjstest10',
+        reason: '[forbidden] cnpmjstestAdmin2 not authorized to modify testmodule-new-1, please contact maintainers: cnpmjstest10',
       })
       .expect(403, done);
     });
@@ -248,8 +248,8 @@ describe('test/controllers/registry/package/save.test.js', function () {
       .set('authorization', utils.adminAuth)
       .send(pkg)
       .expect({
-        error: 'forbidden',
-        reason: 'cannot modify pre-existing version: 0.0.1'
+        error: '[forbidden] cannot modify pre-existing version: 0.0.1',
+        reason: '[forbidden] cannot modify pre-existing version: 0.0.1',
       })
       .expect(403, done);
     });

--- a/test/controllers/registry/package/tag.test.js
+++ b/test/controllers/registry/package/tag.test.js
@@ -42,8 +42,8 @@ describe('test/controllers/registry/package/tag.test.js', function () {
     .set('authorization', utils.adminAuth)
     .send('""')
     .expect({
-      error: 'version_missed',
-      reason: 'version not found'
+      error: '[version_missed] version not found',
+      reason: '[version_missed] version not found',
     })
     .expect(400, done);
   });
@@ -56,8 +56,8 @@ describe('test/controllers/registry/package/tag.test.js', function () {
     .send('"hello"')
     .expect(403)
     .expect({
-      error: 'forbidden',
-      reason: 'setting tag newtag to invalid version: hello: @cnpmtest/testmodule-tag-1/newtag'
+      error: '[forbidden] setting tag newtag to invalid version: hello: @cnpmtest/testmodule-tag-1/newtag',
+      reason: '[forbidden] setting tag newtag to invalid version: hello: @cnpmtest/testmodule-tag-1/newtag',
     }, done);
   });
 
@@ -69,8 +69,8 @@ describe('test/controllers/registry/package/tag.test.js', function () {
     .send('"5.0.0"')
     .expect(403)
     .expect({
-      error: 'forbidden',
-      reason: 'setting tag newtag to unknown version: 5.0.0: @cnpmtest/testmodule-tag-1/newtag'
+      error: '[forbidden] setting tag newtag to unknown version: 5.0.0: @cnpmtest/testmodule-tag-1/newtag',
+      reason: '[forbidden] setting tag newtag to unknown version: 5.0.0: @cnpmtest/testmodule-tag-1/newtag',
     }, done);
   });
 
@@ -93,8 +93,8 @@ describe('test/controllers/registry/package/tag.test.js', function () {
       .send('"1.0.0"')
       .expect(403)
       .expect({
-        error: 'forbidden user',
-        reason: 'cnpmjstest101 not authorized to modify @cnpmtest/update-tag-not-maintainer'
+        error: '[forbidden] cnpmjstest101 not authorized to modify @cnpmtest/update-tag-not-maintainer',
+        reason: '[forbidden] cnpmjstest101 not authorized to modify @cnpmtest/update-tag-not-maintainer',
       }, done);
     });
   });

--- a/test/controllers/registry/package/update.test.js
+++ b/test/controllers/registry/package/update.test.js
@@ -36,8 +36,8 @@ describe('test/controllers/registry/package/update.test.js', function () {
       foo: 'bar'
     })
     .expect({
-      error: 'not_found',
-      reason: 'document not found'
+      error: '[not_found] document not found',
+      reason: '[not_found] document not found',
     })
     .expect(404, done);
   });
@@ -192,7 +192,10 @@ describe('test/controllers/registry/package/update.test.js', function () {
       })
       .set('authorization', utils.otherUserAuth)
       .expect(403)
-      .expect({error: 'invalid operation', reason: 'Can not remove all maintainers'})
+      .expect({
+        error: '[invalid_operation] Can not remove all maintainers',
+        reason: '[invalid_operation] Can not remove all maintainers',
+      })
       .expect('content-type', 'application/json; charset=utf-8', done);
     });
 
@@ -208,8 +211,8 @@ describe('test/controllers/registry/package/update.test.js', function () {
       .set('authorization', utils.secondUserAuth)
       .expect(403)
       .expect({
-        error: 'forbidden user',
-        reason: 'cnpmjstest102 not authorized to modify @cnpmtest/testmodule-update-1'
+        error: '[forbidden] cnpmjstest102 not authorized to modify @cnpmtest/testmodule-update-1',
+        reason: '[forbidden] cnpmjstest102 not authorized to modify @cnpmtest/testmodule-update-1',
       }, done);
     });
 
@@ -288,8 +291,8 @@ describe('test/controllers/registry/package/update.test.js', function () {
         })
         .set('authorization', utils.otherUserAuth)
         .expect({
-          error: 'invalid user name',
-          reason: 'User: `not-exists, not-exists2` not exists'
+          error: '[invalid] User: `not-exists, not-exists2` not exists',
+          reason: '[invalid] User: `not-exists, not-exists2` not exists',
         })
         .expect(403, done);
       });

--- a/test/controllers/registry/user/add.test.js
+++ b/test/controllers/registry/user/add.test.js
@@ -99,8 +99,8 @@ describe('test/controllers/registry/user/add.test.js', function () {
         email: 'cnpmjstest10@cnpmjs.org'
       })
       .expect({
-        error: 'paramError',
-        reason: 'params missing, name, email or password missing.'
+        error: '[param_error] params missing, name, email or password missing',
+        reason: '[param_error] params missing, name, email or password missing',
       })
       .expect(422, done);
     });
@@ -144,8 +144,8 @@ describe('test/controllers/registry/user/add.test.js', function () {
         email: 'cnpmjstest10@cnpmjs.org'
       })
       .expect({
-        error: 'unauthorized',
-        reason: 'Login fail, please check your login name and password'
+        error: '[unauthorized] Login fail, please check your login name and password',
+        reason: '[unauthorized] Login fail, please check your login name and password',
       })
       .expect(401, done);
     });
@@ -166,8 +166,8 @@ describe('test/controllers/registry/user/add.test.js', function () {
         email: 'cnpmjstest10@cnpmjs.org'
       })
       .expect({
-        error: 'UserSeriveAuthError',
-        reason: 'mock user service auth error, please visit http://ooxx.net/user to sigup first'
+        error: 'mock user service auth error, please visit http://ooxx.net/user to sigup first',
+        reason: 'mock user service auth error, please visit http://ooxx.net/user to sigup first',
       })
       .expect(401, done);
     });

--- a/test/controllers/registry/user/update.test.js
+++ b/test/controllers/registry/user/update.test.js
@@ -1,18 +1,4 @@
-/**!
- * cnpmjs.org - test/controllers/registry/user/update.test.js
- *
- * Copyright(c) cnpmjs.org and other contributors.
- * MIT Licensed
- *
- * Authors:
- *  fengmk2 <fengmk2@gmail.com> (http://fengmk2.github.com)
- */
-
 'use strict';
-
-/**
- * Module dependencies.
- */
 
 var request = require('supertest');
 var mm = require('mm');
@@ -83,8 +69,8 @@ describe('controllers/registry/user/update.test.js', function () {
         rev: '1-123'
       })
       .expect({
-        error: 'conflict',
-        reason: 'Document update conflict.'
+        error: '[conflict] Document update conflict',
+        reason: '[conflict] Document update conflict',
       })
       .expect(409, done);
     });
@@ -95,8 +81,8 @@ describe('controllers/registry/user/update.test.js', function () {
       .set('authorization', 'basic ' + Buffer.from('cnpmjstest10:cnpmjstest10').toString('base64'))
       .send({})
       .expect({
-        error: 'paramError',
-        reason: 'params missing, name, email or password missing.'
+        error: '[param_error] params missing, name, email or password missing',
+        reason: '[param_error] params missing, name, email or password missing',
       })
       .expect(422, done);
     });

--- a/test/controllers/registry/user_package.test.js
+++ b/test/controllers/registry/user_package.test.js
@@ -120,8 +120,8 @@ describe('test/controllers/registry/user_package.test.js', function () {
       .get('/-/by-user/n1|n2|n3|n4|n5|n6|n7|n8|n9|n10|n11|n12|n13|n14|n15|n16|n17|n18|n19|n20|n21')
       .expect(400)
       .expect({
-        error: 'bad_request',
-        reason: 'reach max user names limit, must <= 20 user names'
+        error: '[bad_request] reach max user names limit, must <= 20 user names',
+        reason: '[bad_request] reach max user names limit, must <= 20 user names',
       }, done);
     });
   });

--- a/test/controllers/sync.test.js
+++ b/test/controllers/sync.test.js
@@ -52,8 +52,8 @@ describe('test/controllers/sync.test.js', () => {
       .put('/utility_unit_test/sync?publish=true&nodeps=true')
       .expect(403)
       .expect({
-        error: 'no_perms',
-        reason: 'Only admin can publish'
+        error: '[no_perms] Only admin can publish',
+        reason: '[no_perms] Only admin can publish',
       }, done);
     });
 

--- a/test/middleware/auth.test.js
+++ b/test/middleware/auth.test.js
@@ -55,8 +55,8 @@ describe('test/middleware/auth.test.js', function () {
         .put('/-/user/org.couchdb.user:cnpmjstest10/-rev/1')
         .set('authorization', 'basic ' + Buffer.from('cnpmjstest10:cnpmjstest10').toString('base64'))
         .expect({
-          error: 'UserSeriveAuthError',
-          reason: 'mock user service auth error, please visit http://ooxx.net/user to sigup first'
+          error: '[UserSeriveAuthError] mock user service auth error, please visit http://ooxx.net/user to sigup first',
+          reason: '[UserSeriveAuthError] mock user service auth error, please visit http://ooxx.net/user to sigup first',
         })
         .expect(401, done);
       });
@@ -73,8 +73,8 @@ describe('test/middleware/auth.test.js', function () {
       .get('/')
       .set('Accept', 'application/json')
       .expect({
-        error: 'unauthorized',
-        reason: 'login first'
+        error: '[unauthorized] login first',
+        reason: '[unauthorized] login first',
       })
       .expect(401, done);
     });

--- a/test/middleware/publishable.test.js
+++ b/test/middleware/publishable.test.js
@@ -108,8 +108,8 @@ describe('middleware/publishable.test.js', function () {
       }
     })
     .expect({
-      error: 'no_perms',
-      reason: 'Private mode enable, only admin can publish this module'
+      error: '[no_perms] Private mode enable, only admin can publish this module',
+      reason: '[no_perms] Private mode enable, only admin can publish this module',
     })
     .expect(403, done);
   });

--- a/test/middleware/sync_by_install.test.js
+++ b/test/middleware/sync_by_install.test.js
@@ -14,8 +14,8 @@ describe('test/middleware/sync_by_install.test.js', () => {
     .get('/@cnpmtest/foo')
     .set('User-Agent', 'node/v4.4.4')
     .expect({
-      error: 'not_found',
-      reason: 'document not found',
+      error: '[not_found] document not found',
+      reason: '[not_found] document not found',
     })
     .expect(404, done);
   });


### PR DESCRIPTION
@fengmk2 
一、我把 `.js` 代码里面的改了。根据 `npm-registry-fetch` 的实现来说，reason字段是一定被放弃了。
二、有4个地方没有改，因为没找到规律。
* cnpmjs.org/controllers/sync_module_worker.js
* cnpmjs.org/docs/flow/adduser.md
* cnpmjs.org/docs/flow/publish.md
* cnpmjs.org/docs/registry-api.md


比如 `cnpmjs.org/controllers/sync_module_worker.js` 里面，我不知道以谁为准
```shell
$ curl https://replicate.npmjs.com/not_found_alsotang
{"error":"not_found","reason":"missing"}
$ curl https://registry.npmjs.com/not_found_alsotang
{"error":"Not found"}
```

再比如 cnpmjs.org/docs/registry-api.md

```shell
$ curl -u "username:password" https://registry.npmjs.org/
{"error":"unauthorized","reason":"Name or password is incorrect."}
$ curl  https://registry.npmjs.org/-/user/org.couchdb.user:not_found_alsotang
{"ok":false,"message":"Scope not found"}
```

fix #1443 