### PR TITLE
去掉save.js中maintainer的判断，在publishable中已经做判断了

### DIFF
--- a/controllers/registry/package/save.js
+++ b/controllers/registry/package/save.js
@@ -39,19 +39,6 @@ module.exports = function* save(next) {
     return;
   }
 
-  // check maintainers
-  var result = yield packageService.authMaintainer(name, username);
-  if (!result.isMaintainer) {
-    this.status = 403;
-    const error = '[forbidden] ' +  username + ' not authorized to modify ' + name +
-      ', please contact maintainers: ' + result.maintainers.join(', ');
-    this.body = {
-      error,
-      reason: error,
-    };
-    return;
-  }
-
   if (!filename) {
     var hasDeprecated = false;
     for (var v in pkg.versions) {


### PR DESCRIPTION
这里的判断应该是冗余的，前面在publishable 中间件中已经做了判断，这里判断会导致admin 不能在别人发包的地方继续发包，就只能和普通用户一样等maintainer加权限了，