### PR TITLE
fix: failure to start MySQL using docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,6 @@ services:
     image: mysql:5.6
     restart: always
     environment :
-      MYSQL_USER: root      
       MYSQL_ALLOW_EMPTY_PASSWORD: "yes"      
       MYSQL_DATABASE: cnpmjs_test
       MYSQL_ROOT_HOST: "%"


### PR DESCRIPTION
MySQL [docker-entrypoint.sh](https://github.com/docker-library/mysql/blob/d60655b1b42f677c315d5fe2ca0e87126ca921f5/5.6/docker-entrypoint.sh#L156)
2022-01-08 14:37:00+00:00 [Note] [Entrypoint]: Entrypoint script for MySQL Server 5.6.51-1debian9 started.
2022-01-08 14:37:00+00:00 [ERROR] [Entrypoint]: MYSQL_USER="root", MYSQL_USER and MYSQL_PASSWORD are for configuring a regular user and cannot be used for the root user
    Remove MYSQL_USER="root" and use one of the following to control the root user password:
    - MYSQL_ROOT_PASSWORD
    - MYSQL_ALLOW_EMPTY_PASSWORD
    - MYSQL_RANDOM_ROOT_PASSWORD