### PR TITLE
Update makefile error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,13 @@ TIMEOUT = 600000
 MOCHA_OPTS =
 DB = sqlite
 
+all: install
+
+install: install-dependency init-database
+
+install-dependency:
+	@npm install
+
 jshint:
 	@node_modules/.bin/jshint .
 

--- a/README.md
+++ b/README.md
@@ -76,8 +76,8 @@ you only need to change the registry in client config.
 # clone from git
 $ git clone https://github.com/cnpm/cnpmjs.org.git
 
-# install dependencies
-$ make install
+# install dependencies && init sqlite3 database
+$ make
 
 # test
 $ make test


### PR DESCRIPTION
In the previous readme, the doc suggests people use `make install` command to install the dependency which has not existed in Makefile.

So I add some extra commands to support people just run `make` command to install the dependency and init the database

Signed-off-by: Manjusaka <me@manjusaka.me>