### PR TITLE
refactor: replace deprecated String.prototype.substr()

### DIFF
--- a/services/token.js
+++ b/services/token.js
@@ -113,7 +113,7 @@ function redacteToken(token) {
   if (!token) {
     return null;
   }
-  return `${token.substr(0, 6)}...${token.substr(-6)}`;
+  return `${token.slice(0, 6)}...${token.slice(-6)}`;
 }
 
 function createTokenKey(token) {


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.