### PR TITLE
fix: download row create error

### DIFF
--- a/controllers/registry/package/download.js
+++ b/controllers/registry/package/download.js
@@ -130,9 +130,12 @@ defer.setInterval(function* () {
         err.message += '; name: ' + name + ', count: ' + count + ', date: ' + date;
         logger.error(err);
       }
-      // save back to globalDownloads, try again next time
-      count = (globalDownloads.get(name) || 0) + count;
-      globalDownloads.set(name, count);
+      var pkgExist = yield packageService.getModuleLastModified(name);
+      if (pkgExist) {
+        // save back to globalDownloads, try again next time
+        count = (globalDownloads.get(name) || 0) + count;
+        globalDownloads.set(name, count);
+      }
     }
   }
   saving = false;


### PR DESCRIPTION
> 包名超长时，更新下载记录接口会无限重试
* 更新下载记录前，先判断当前包名是否存在

-------------

> When the package name is too long, the update download record interface will retry indefinitely.

* Check pkg exists, before updating the download record.